### PR TITLE
Feature: Sticky Footer Mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ If you are a restraunt that would be interested in trialing this service, feel f
 Love,
 Chris
 
+## design file
+
+https://www.figma.com/file/Q671pbdFk3omco20xmxk5o/foodouken.com?node-id=1245%3A57965
+
+If you have a question about design feel free to reference our design doc, add a comment, or reach out on https://discord.gg/5T7D33c
+
 ## frontend (vue.js/tailwind css)
 
 Most of the site is setup using endpoints provided by meredith-core, our REST API:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,23 @@ If you would like to get involved, we are seeking programmers, experienced marke
 If you are a restraunt that would be interested in trialing this service, feel free to drop a comment below or pm me for more details.
 
 Love,
-Chris.
+Chris
+
+## frontend (vue.js/tailwind css)
+
+Most of the site is setup using endpoints provided by meredith-core, our REST API:
+
+https://stagingapi.whynot.earth/api/v0/pages/slug/bang-bang-bakery-cafe/
+
+Your job is to style and beautify those endpoints. Since we are working with tailwind css, many of the finer nuances of loading, animations, transitions still need to be done. 
+
+## backend (.net)
+
+We host on Google Cloud Platform, postgres database. Our API, meredith core can be found here:
+
+https://github.com/whynotearth/meredith-core
+
+Your job is to create manipulate the API to be better suited for food delivery. Currently, we are mashing a lot json in a single cell in our database and punching out endpoints. We will want to segment that into better modules. 
 
 
 ## Project setup

--- a/src/components/cart/Cart.vue
+++ b/src/components/cart/Cart.vue
@@ -16,13 +16,13 @@
 
       <div><span class="text-gray-500 text-sm">Delivery Fee</span></div>
       <div class="text-right">
-        <span class="text-gray-500 text-sm">-</span>
+        <span class="text-gray-500 text-sm">${{ deliveryFee }}</span>
       </div>
     </div>
     <div class="grid grid-cols-2 gap-1 mt-2">
       <div><span class="text-gray-400 text-2xl font-bold">Total</span></div>
       <div class="text-right">
-        <div><span class="text-gray-400 text-2xl font-bold">-</span></div>
+        <span class="text-gray-400 text-2xl font-bold">${{ total }}</span>
       </div>
     </div>
   </div>
@@ -38,7 +38,7 @@ export default {
     CartItem
   },
   computed: {
-    ...mapGetters('cart', ['cartItems', 'subTotal'])
+    ...mapGetters('cart', ['cartItems', 'subTotal', 'total', 'deliveryFee'])
   },
   filters: {
     formatPrice: price => {

--- a/src/components/cart/Cart.vue
+++ b/src/components/cart/Cart.vue
@@ -10,19 +10,23 @@
       <div><span class="text-gray-500 text-sm">Sub-Total</span></div>
       <div class="text-right">
         <span class="text-gray-500 text-sm">
-          ${{ subTotal | formatPrice }}
+          {{ subTotal | formatPrice }}
         </span>
       </div>
 
       <div><span class="text-gray-500 text-sm">Delivery Fee</span></div>
       <div class="text-right">
-        <span class="text-gray-500 text-sm">${{ deliveryFee }}</span>
+        <span class="text-gray-500 text-sm">{{
+          deliveryFee | formatPrice
+        }}</span>
       </div>
     </div>
     <div class="grid grid-cols-2 gap-1 mt-2">
       <div><span class="text-gray-400 text-2xl font-bold">Total</span></div>
       <div class="text-right">
-        <span class="text-gray-400 text-2xl font-bold">${{ total }}</span>
+        <span class="text-gray-400 text-2xl font-bold">{{
+          total | formatPrice
+        }}</span>
       </div>
     </div>
   </div>
@@ -42,7 +46,7 @@ export default {
   },
   filters: {
     formatPrice: price => {
-      return price.toFixed(2);
+      return `$${price.toFixed(2)}`;
     }
   }
 };

--- a/src/components/forms/CheckoutForm.vue
+++ b/src/components/forms/CheckoutForm.vue
@@ -1,16 +1,23 @@
 <template>
   <form action="" class="max-w-sm m-auto">
-    <customer-info />
+    <customer-info v-if="page === 1" />
+    <customer-address v-if="page === 2" />
   </form>
 </template>
 
 <script>
 import CustomerInfo from '@/components/forms/CustomerInfo';
+import CustomerAddress from '@/components/forms/CustomerAddress';
+import { mapGetters } from 'vuex';
 
 export default {
   name: 'CheckoutForm',
   components: {
-    CustomerInfo
+    CustomerInfo,
+    CustomerAddress
+  },
+  computed: {
+    ...mapGetters('form', ['page'])
   }
 };
 </script>

--- a/src/components/forms/CustomerAddress.vue
+++ b/src/components/forms/CustomerAddress.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="w-full">
+    <div class="bg-secondary px-2 py-4 rounded-lg">
+      <material-input
+        v-model="street"
+        type="text"
+        label="Street Address"
+        placeholder="Street name and number"
+        :required="true"
+      />
+      <material-input
+        v-model="town"
+        type="text"
+        label="City"
+        placeholder="Town or City Area"
+        :required="true"
+      />
+      <material-input
+        v-model="floor"
+        type="text"
+        label="Floor"
+        :required="true"
+      />
+      <material-input
+        v-model="apartment"
+        type="text"
+        label="Apartment #"
+        :required="true"
+      />
+      <material-input
+        v-model="parking"
+        type="text"
+        label="Where to park"
+        :required="true"
+      />
+    </div>
+    <div class="w-full text-center my-4">
+      <Button title="Choose delivery time" @clicked="pageChange(3)" />
+    </div>
+  </div>
+</template>
+
+<script>
+import MaterialInput from '@/components/inputs/MaterialInput.vue';
+import Button from '@/components/Button.vue';
+import { mapGetters, mapMutations } from 'vuex';
+
+export default {
+  name: 'CustomerAddress',
+  components: {
+    MaterialInput,
+    Button
+  },
+  computed: {
+    ...mapGetters('form', [
+      'getTown',
+      'getFloor',
+      'getApartment',
+      'getParking',
+      'getStreet'
+    ]),
+    town: {
+      get() {
+        return this.getTown;
+      },
+      set(value) {
+        this.updateTown(value);
+      }
+    },
+    floor: {
+      get() {
+        return this.getFloor;
+      },
+      set(value) {
+        this.updateFloor(value);
+      }
+    },
+    street: {
+      get() {
+        return this.getStreet;
+      },
+      set(value) {
+        this.updateStreet(value);
+      }
+    },
+    parking: {
+      get() {
+        return this.getParking;
+      },
+      set(value) {
+        this.updateParking(value);
+      }
+    },
+    apartment: {
+      get() {
+        return this.getApartment;
+      },
+      set(value) {
+        this.updateApartment(value);
+      }
+    }
+  },
+  methods: {
+    ...mapMutations('form', [
+      'updateTown',
+      'updateFloor',
+      'updateStreet',
+      'updateParking',
+      'updateApartment',
+      'pageChange'
+    ])
+  }
+};
+</script>
+
+<style></style>

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -23,7 +23,7 @@
       <text-area v-model="specialRequest" label="Special requests" />
     </div>
     <div class="w-full text-center my-4">
-      <Button title="Add address" />
+      <Button title="Add address" @clicked="pageChange(2)" />
     </div>
   </div>
 </template>
@@ -32,6 +32,7 @@
 import MaterialInput from '@/components/inputs/MaterialInput.vue';
 import TextArea from '@/components/inputs/TextArea.vue';
 import Button from '@/components/Button.vue';
+import { mapGetters, mapMutations } from 'vuex';
 
 export default {
   name: 'CustomerInfo',
@@ -40,13 +41,54 @@ export default {
     TextArea,
     Button
   },
-  data() {
-    return {
-      name: '',
-      email: '',
-      phone: '',
-      specialRequest: ''
-    };
+  computed: {
+    ...mapGetters('form', [
+      'getName',
+      'getEmail',
+      'getPhone',
+      'getSpecialRequest'
+    ]),
+    name: {
+      get() {
+        return this.getName;
+      },
+      set(value) {
+        this.updateName(value);
+      }
+    },
+    email: {
+      get() {
+        return this.getEmail;
+      },
+      set(value) {
+        this.updateEmail(value);
+      }
+    },
+    phone: {
+      get() {
+        return this.getName;
+      },
+      set(value) {
+        this.updatePhone(value);
+      }
+    },
+    specialRequest: {
+      get() {
+        return this.getName;
+      },
+      set(value) {
+        this.updateSpecialRequest(value);
+      }
+    }
+  },
+  methods: {
+    ...mapMutations('form', [
+      'updateName',
+      'updateEmail',
+      'updatePhone',
+      'updateSpecialRequest',
+      'pageChange'
+    ])
   }
 };
 </script>

--- a/src/components/inputs/MaterialInput.vue
+++ b/src/components/inputs/MaterialInput.vue
@@ -8,6 +8,7 @@
       @input="$emit('input', $event.target.value)"
       :required="required"
       :pattern="pattern"
+      :placeholder="placeholder || label"
     />
     <label
       for="email"
@@ -29,6 +30,9 @@ export default {
     label: {
       type: String,
       default: 'Label'
+    },
+    placeholder: {
+      type: String
     },
     type: {
       type: String,
@@ -71,7 +75,7 @@ export default {
 .label {
   transition: all 0.2s ease-out;
   transition: all 200ms;
-  opacity: 0.5;
+  opacity: 0;
   padding: 0 5px;
   z-index: 1;
 }

--- a/src/components/inputs/TextArea.vue
+++ b/src/components/inputs/TextArea.vue
@@ -5,6 +5,7 @@
       :class="value.length > 0 ? 'filled' : ''"
       :value="value"
       @input="$emit('input', $event.target.value)"
+      :placeholder="placeholder || label"
     ></textarea>
     <label
       for="email"
@@ -26,6 +27,9 @@ export default {
     label: {
       type: String,
       default: 'Label'
+    },
+    placeholder: {
+      type: String
     }
   },
   data() {
@@ -56,7 +60,7 @@ export default {
 .label {
   transition: all 0.2s ease-out;
   transition: all 200ms;
-  opacity: 0.5;
+  opacity: 0;
   padding: 0 5px;
   z-index: 1;
 }

--- a/src/components/sticky-cta/StickyCta.vue
+++ b/src/components/sticky-cta/StickyCta.vue
@@ -1,0 +1,57 @@
+<template>
+  <div
+    class="sticky inset-x-0 bottom-0 w-full"
+    v-bind:class="[mobileOnly ? 'md:hidden' : '']"
+  >
+    <div
+      class="flex flex-row items-center p-2"
+      v-bind:class="[
+        backgroundColor,
+        border,
+        fontColor,
+        boxShadow ? 'shadow-md' : '',
+        mobileOnly ? 'md:hidden' : ''
+      ]"
+    >
+      <div class="flex-1">{{ leftContent }}</div>
+      <div class="flex-grow text-center">
+        <a v-if="ctaLink" :href="ctaLink">{{ centerContent }}</a>
+        <span v-else>{{ centerContent }}</span>
+      </div>
+      <div class="flex-1 text-right">{{ rightContent }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'StickyCta',
+  props: {
+    leftContent: String,
+    centerContent: String,
+    rightContent: String,
+    ctaLink: String,
+    backgroundColor: {
+      type: String,
+      default: 'bg-button'
+    },
+    border: {
+      type: String
+    },
+    fontColor: {
+      type: String,
+      default: 'text-white'
+    },
+    boxShadow: {
+      type: Boolean,
+      default: true
+    },
+    mobileOnly: {
+      type: Boolean,
+      default: false
+    }
+  }
+};
+</script>
+
+<style />

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex';
 import category from './modules/category';
 import cart from './modules/cart';
 import home from './modules/home';
+import form from './modules/form';
 
 Vue.use(Vuex);
 
@@ -13,6 +14,7 @@ export default new Vuex.Store({
   modules: {
     home,
     category,
-    cart
+    cart,
+    form
   }
 });

--- a/src/store/modules/cart.js
+++ b/src/store/modules/cart.js
@@ -1,6 +1,9 @@
 // initial state
 const state = {
-  cartItems: []
+  cartItems: [],
+  deliveryFee: 1,
+  subTotal: 0,
+  total: 0
 };
 
 // getters
@@ -9,11 +12,19 @@ const getters = {
     return state.cartItems;
   },
   subTotal: state => {
-    return state.cartItems.reduce(
+    state.subTotal = state.cartItems.reduce(
       (runningTotal, cartItem) =>
         runningTotal + cartItem.product.price * cartItem.count,
       0
     );
+    return state.subTotal;
+  },
+  deliveryFee: state => {
+    return state.deliveryFee;
+  },
+  total: state => {
+    state.total = state.subTotal + state.deliveryFee;
+    return state.total;
   }
 };
 

--- a/src/store/modules/form.js
+++ b/src/store/modules/form.js
@@ -1,0 +1,81 @@
+// initial state
+const state = {
+  formData: {
+    customerInfo: {
+      name: '',
+      email: '',
+      phone: '',
+      specialRequest: ''
+    },
+    customerAddress: {
+      street: '',
+      town: '',
+      floor: '',
+      apartment: '',
+      parking: ''
+    },
+    deliveryTime: {},
+    paymentMethod: ''
+  },
+  page: 1
+};
+
+// getters
+const getters = {
+  formData: state => state.formData,
+  page: state => state.page,
+  getName: state => state.formData.customerInfo.name,
+  getEmail: state => state.formData.customerInfo.email,
+  getPhone: state => state.formData.customerInfo.phone,
+  getSpecialRequest: state => state.formData.customerInfo.specialRequest,
+  getStreet: state => state.formData.customerAddress.street,
+  getTown: state => state.formData.customerAddress.town,
+  getFloor: state => state.formData.customerAddress.floor,
+  getApartment: state => state.formData.customerAddress.apartment,
+  getParking: state => state.formData.customerAddress.parking
+};
+
+// actions
+const actions = {};
+
+// mutations
+const mutations = {
+  pageChange(state, payload) {
+    state.page = payload;
+  },
+  updateName(state, payload) {
+    state.formData.customerInfo.name = payload;
+  },
+  updateEmail(state, payload) {
+    state.formData.customerInfo.email = payload;
+  },
+  updatePhone(state, payload) {
+    state.formData.customerInfo.phone = payload;
+  },
+  updateSpecialRequest(state, payload) {
+    state.formData.customerInfo.specialRequest = payload;
+  },
+  updateStreet(state, payload) {
+    state.formData.customerAddress.street = payload;
+  },
+  updateTown(state, payload) {
+    state.formData.customerAddress.town = payload;
+  },
+  updateFloor(state, payload) {
+    state.formData.customerAddress.floor = payload;
+  },
+  updateApartment(state, payload) {
+    state.formData.customerAddress.apartment = payload;
+  },
+  updateParking(state, payload) {
+    state.formData.customerAddress.parking = payload;
+  }
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+};

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -16,7 +16,10 @@
       </div>
       <div class="lg:w-4/12 lg:ml-4">
         <checkout-form v-if="form" />
-        <h3 class="text-5xl text-white font-bold text-center mb-8">
+        <h3
+          class="text-5xl text-white font-bold text-center mb-8"
+          id="cartHeader"
+        >
           Cart
         </h3>
         <template v-if="cart.length">
@@ -50,6 +53,7 @@ import CategoryHolder from '@/components/categories/CategoryHolder.vue';
 import Button from '@/components/Button.vue';
 import Cart from '@/components/cart/Cart.vue';
 import EmptyCart from '@/components/cart/EmptyCart.vue';
+import StickyCta from '@/components/sticky-cta/StickyCta.vue';
 import { mapGetters, mapActions } from 'vuex';
 
 export default {
@@ -61,6 +65,7 @@ export default {
     Button,
     Cart,
     EmptyCart,
+    StickyCta,
     CheckoutForm: () => import('@/components/forms/CheckoutForm.vue')
   },
   data() {
@@ -80,8 +85,14 @@ export default {
       loadingCategory: 'category/getCategoryLoading',
       orgData: 'home/getOrgData',
       categories: 'home/getCategories',
-      cart: 'cart/cartItems'
+      cart: 'cart/cartItems',
+      total: 'cart/total'
     })
+  },
+  filters: {
+    formatPrice: price => {
+      return `$${price.toFixed(2)}`;
+    }
   }
 };
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -24,13 +24,22 @@
           <p class="text-gray-500 text-center text-lg my-4">
             Estimated Delivery Time: 45 minutes.
           </p>
-          <div v-if="!form" class="w-full text-center my-4">
+          <div v-if="!form" class="w-full text-center my-4 hidden md:block">
             <Button title="Order now" @clicked="form = true" />
           </div>
         </template>
         <empty-cart v-else />
       </div>
     </section>
+    <sticky-cta
+      v-if="cart.length"
+      centerContent="Order Now"
+      v-bind:rightContent="total | formatPrice"
+      border="rounded-lg"
+      v-bind:boxShadow="true"
+      v-bind:mobileOnly="true"
+      class="mt-8 pb-4"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
This PR addresses Issue #33 "add view cart fixed bar on mobile after cart update"

* Move `$` from template portion of Cart to the `formatPrice` filter (8e49dc3)
  * can now pass fully formatted price down to Cart's child components
* Addition of general sticky CTA (call to action) component (ecc6a87)
* Use sticky CTA component to make sticky footer with "View Cart" CTA and Sub-Total appear on mobile when customer has at least one cart item (e7846f1)
  * Added anchor tag to "Cart" `h3` header so that when customer clicks "View Cart", it scrolls them to the top of the cart