### PR TITLE
chore: placeholders on inputs and textareas disappear on focus

### DIFF
--- a/src/components/inputs/MaterialInput.vue
+++ b/src/components/inputs/MaterialInput.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mb-4 relative">
     <input
-      class="input appearance-none relative bg-transparent border border-gray-600 rounded w-full px-4 py-3 focus:border-gray-500 active:border-gray-500"
+      class="input appearance-none relative bg-transparent border border-gray-600 rounded w-full px-4 py-3 focus:outline-none focus:border-gray-500 focus:border-2 active:border-gray-500 active:border-2"
       :class="value.length > 0 ? 'filled' : ''"
       :type="type"
       :value="value"

--- a/src/components/inputs/MaterialInput.vue
+++ b/src/components/inputs/MaterialInput.vue
@@ -71,6 +71,10 @@ export default {
   z-index: 3;
 }
 
+.input:focus::placeholder {
+  color: transparent;
+}
+
 .label {
   transition: all 0.2s ease-out;
   transition: all 200ms;

--- a/src/components/inputs/TextArea.vue
+++ b/src/components/inputs/TextArea.vue
@@ -56,6 +56,10 @@ export default {
   z-index: 3;
 }
 
+.input:focus::placeholder {
+  color: transparent;
+}
+
 .label {
   transition: all 0.2s ease-out;
   transition: all 200ms;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,7 +20,7 @@ module.exports = {
   },
   variants: {
     backgroundColor: ['responsive', 'hover', 'focus', 'active'],
-    borderWidth: ['focus', 'active']
+    borderWidth: ['responsive', 'hover', 'focus', 'active']
   },
   plugins: []
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,8 @@ module.exports = {
     }
   },
   variants: {
-    backgroundColor: ['responsive', 'hover', 'focus', 'active']
+    backgroundColor: ['responsive', 'hover', 'focus', 'active'],
+    borderWidth: ['focus', 'active']
   },
   plugins: []
 };


### PR DESCRIPTION
This addresses Issue #49 

- placeholders on inputs and textarea elements disappear on focus/active
- increased border width on input and textarea elements on focus/active