### PR TITLE
feat:product card opacity decrease on hover

### DIFF
--- a/src/components/cards/ProductCard.vue
+++ b/src/components/cards/ProductCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     @click="addCartProduct(product)"
-    class="bg-secondary flex flex-row shadow-md rounded-lg h-24 mb-4 cursor-pointer"
+    class="product-card bg-secondary flex flex-row shadow-md rounded-lg h-24 mb-4 cursor-pointer transition duration-300 transform hover:opacity-75"
   >
     <img
       :src="product.image"
@@ -60,7 +60,7 @@ export default {
   background-position: center;
   transition: background 0.4s;
 }
-.ripple:hover {
+.product-card:hover .ripple {
   background: #1d484f radial-gradient(circle, transparent 1%, #1d484f 1%)
     center/15000%;
 }


### PR DESCRIPTION
This addresses issue #87 

Now when hovering over a product card, the card and the button inside of it will have their opacities reduced at the same time

An issue might be that the transition durations for the parent div's opacity and the button's background differ by a slight amount, but there is no `duration-400` class utility in Tailwind that I could put on the parent div to exactly match the existing `transition: background 0.4s;` on the button. If this is not fine, then we can change the CSS by 0.1s