### PR TITLE
chore: justify content default on category holder

### DIFF
--- a/src/components/categories/CategoryHolder.vue
+++ b/src/components/categories/CategoryHolder.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="deleteMargins disable-scrollbars overflow-x-auto scrolling-touch flex flex-no-wrap md:justify-center mt-6"
+    class="deleteMargins disable-scrollbars overflow-x-auto scrolling-touch flex flex-no-wrap mt-6"
   >
     <category
       v-for="(category, index) in categories"


### PR DESCRIPTION
We left-align categories in the category holder to avoid the "for you" icon to become obscured if there are too many categories, like so:

![image](https://user-images.githubusercontent.com/20192983/79010032-dff31180-7b15-11ea-86b1-fb8f2cebf42e.png)

After fix:

![image](https://user-images.githubusercontent.com/20192983/79010061-f5683b80-7b15-11ea-8d24-a696109e4a5b.png)
