### PR TITLE
feat: add transitions and spinners while category loads

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,14 @@
 <template>
   <div id="app" class="font-sans bg-primary h-full text-gray-300 text-lg">
     <Spinner class="min-h-screen" v-if="getLoading" />
-    <div v-show="!getLoading">
-      <router-view
-        class="md:px-8 pb-8 px-4 max-w-screen-xxl mx-auto min-h-screen"
-      />
-      <Footer />
-    </div>
+    <transition name="fade">
+      <div v-show="!getLoading">
+        <router-view
+          class="md:px-8 pb-8 px-4 max-w-screen-xxl mx-auto min-h-screen"
+        />
+        <Footer />
+      </div>
+    </transition>
   </div>
 </template>
 
@@ -36,5 +38,12 @@ body {
 #app {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.fade-enter-active {
+  transition: opacity 0.3s ease;
+}
+.fade-enter /* .fade-leave-active below version 2.1.8 */ {
+  opacity: 0;
 }
 </style>

--- a/src/store/modules/home.js
+++ b/src/store/modules/home.js
@@ -2,7 +2,7 @@ import { httpClient } from '@/services/httpClient';
 
 // initial state
 const state = {
-  loading: false,
+  loading: true,
   orgData: {},
   categories: []
 };
@@ -26,7 +26,6 @@ const getters = {
 // actions
 const actions = {
   fetchHomeData({ commit }) {
-    commit('changeHomeLoading', true);
     let org = process.env.VUE_APP_ORG_NAME;
     return new Promise((resolve, reject) => {
       httpClient.get(`/pages/slug/${org}/${org}`).then(

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,7 +9,10 @@
           {{ category.title }}
         </h3>
         <p class="text-gray-500 text-center mb-8 text-lg">Prices per piece</p>
-        <card-holder />
+        <transition name="products-container" mode="out-in">
+          <Spinner v-if="loadingCategory" />
+          <card-holder v-else />
+        </transition>
       </div>
       <div class="lg:w-4/12 lg:ml-4">
         <div ref="checkoutFormContainer">
@@ -60,6 +63,7 @@ import Button from '@/components/Button.vue';
 import Cart from '@/components/cart/Cart.vue';
 import EmptyCart from '@/components/cart/EmptyCart.vue';
 import CheckoutForm from '@/components/forms/CheckoutForm.vue';
+import Spinner from '@/components/Spinner.vue';
 import { mapGetters, mapActions, mapMutations } from 'vuex';
 
 export default {
@@ -71,7 +75,8 @@ export default {
     Button,
     Cart,
     EmptyCart,
-    CheckoutForm
+    CheckoutForm,
+    Spinner
   },
   created() {
     this.fetchHomeData();
@@ -87,6 +92,7 @@ export default {
   computed: {
     ...mapGetters({
       category: 'category/getCategory',
+      loadingCategory: 'category/getCategoryLoading',
       orgData: 'home/getOrgData',
       categories: 'home/getCategories',
       cart: 'cart/cartItems',
@@ -102,3 +108,14 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+.products-container-enter-active,
+.products-container-leave-active {
+  transition: opacity 0.3s ease;
+}
+.products-container-enter,
+.products-container-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,7 +9,7 @@
           {{ category.title }}
         </h3>
         <p class="text-gray-500 text-center mb-8 text-lg">Prices per piece</p>
-        <transition name="products-container" mode="out-in">
+        <transition name="fade" mode="out-in">
           <Spinner v-if="loadingCategory" />
           <card-holder v-else />
         </transition>
@@ -110,12 +110,10 @@ export default {
 </script>
 
 <style scoped>
-.products-container-enter-active,
-.products-container-leave-active {
+.fade-leave-active {
   transition: opacity 0.3s ease;
 }
-.products-container-enter,
-.products-container-leave-to {
+.fade-leave-to {
   opacity: 0;
 }
 </style>


### PR DESCRIPTION
When we switch between categories, we show the loading "spinner" component. We also add fade transitions between spinner and category components to make for a smoother experience.