### PR TITLE
chore: remove uppercase utility from button component

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -6,7 +6,7 @@
     :href="href"
     :to="to"
   >
-    <span class="text-white uppercase">
+    <span class="text-white">
       {{ title }}
     </span>
   </component>


### PR DESCRIPTION
We remove the uppercase utility from the button component as discussed with @paulchrisluke 