### PR TITLE
feat: checkout progress nav refresh (partial)

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -1,7 +1,18 @@
 <template>
   <component
     :is="type"
-    class="rounded-full bg-button px-10 py-2 ripple cursor-pointer border-none"
+    class="ripple cursor-pointer border-none"
+    :class="[
+      width,
+      backgroundColor,
+      fontSize,
+      fontWeight,
+      textAlign,
+      textTransform,
+      paddingLeft,
+      paddingRight,
+      borderRadius
+    ]"
     @click="$emit('clicked')"
     :href="href"
     :to="to"
@@ -25,6 +36,41 @@ export default {
     title: {
       type: String,
       default: 'Button'
+    },
+    width: {
+      type: String
+    },
+    backgroundColor: {
+      type: String,
+      default: 'bg-button'
+    },
+    fontSize: {
+      type: String
+    },
+    fontWeight: {
+      type: String
+    },
+    textAlign: {
+      type: String
+    },
+    textTransform: {
+      type: String
+    },
+    paddingLeft: {
+      type: String,
+      default: 'px-10'
+    },
+    paddingRight: {
+      type: String,
+      default: 'py-2'
+    },
+    border: {
+      type: String,
+      default: 'border-none'
+    },
+    borderRadius: {
+      type: String,
+      default: 'rounded-full'
     }
   },
   computed: {

--- a/src/components/forms/CheckoutForm.vue
+++ b/src/components/forms/CheckoutForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="max-w-sm m-auto">
-    <checkout-stepper />
+    <checkout-stepper v-if="page < 6" />
     <customer-info v-if="page === 1" />
     <customer-address v-if="page === 2" />
     <delivery-time v-if="page === 3" />

--- a/src/components/forms/CheckoutNavBar.vue
+++ b/src/components/forms/CheckoutNavBar.vue
@@ -1,0 +1,53 @@
+<template>
+  <div
+    class="w-full text-center md:my-4 flex sticky lg:relative inset-x-0 bottom-0 z-10"
+  >
+    <Button
+      title="◄ Back"
+      :width="'w-1/3'"
+      :backgroundColor="'bg-footer'"
+      :fontSize="'text-sm'"
+      :fontWeight="'font-semibold'"
+      :textAlign="'text-left'"
+      :textTransform="'uppercase'"
+      :paddingLeft="'px-4'"
+      :paddingRight="'py-4'"
+      :borderRadius="'rounded-none'"
+      @clicked="$emit('previousStep')"
+      v-if="page != 1"
+    />
+    <Button
+      :title="nextStepText"
+      :width="'flex-grow'"
+      :backgroundColor="'bg-button'"
+      :fontSize="'text-sm'"
+      :fontWeight="'font-semibold'"
+      :textAlign="'text-right'"
+      :textTransform="'uppercase'"
+      :paddingLeft="'px-4'"
+      :paddingRight="'py-4'"
+      :borderRadius="'rounded-none'"
+      @clicked="$emit('nextStep')"
+    />
+  </div>
+</template>
+
+<script>
+import Button from '@/components/Button.vue';
+import { mapGetters } from 'vuex';
+
+export default {
+  name: 'CheckoutNavBar',
+  components: {
+    Button
+  },
+  props: {
+    nextStepText: {
+      type: String
+    }
+  },
+  computed: {
+    ...mapGetters('form', ['page'])
+  }
+};
+</script>

--- a/src/components/forms/CheckoutStepper.vue
+++ b/src/components/forms/CheckoutStepper.vue
@@ -25,8 +25,8 @@
       </svg>
     </div>
     <div class="flex-grow text-right leading-tight p-4">
-      <h3 class="text-xl md:text-2xl font-bold">{{ pageHeader(page) }}</h3>
-      <h4 class="text-base md:text-xl text-inactive">
+      <h3 class="text-xl font-bold">{{ pageHeader(page) }}</h3>
+      <h4 class="text-base text-inactive">
         {{ pageSubheader(page) | formatPageSubHeader }}
       </h4>
     </div>
@@ -50,10 +50,10 @@ export default {
     pageHeader(pageNum) {
       switch (pageNum) {
         case 1: {
-          return 'Customer Info';
+          return 'Your Info';
         }
         case 2: {
-          return 'Customer Address';
+          return 'Your Address';
         }
         case 3: {
           return 'Delivery Time';
@@ -62,7 +62,7 @@ export default {
           return 'Payment Method';
         }
         case 5: {
-          return 'Review & Order';
+          return 'Review Your Order';
         }
         case 6: {
           return '';

--- a/src/components/forms/CheckoutStepper.vue
+++ b/src/components/forms/CheckoutStepper.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="max-w-sm m-auto bg-footer shadow-md mb-4 flex items-center">
+  <div
+    class="max-w-sm m-auto bg-footer shadow-md mb-4 flex items-center sticky lg:relative inset-x-0 top-0 z-10"
+  >
     <div>
       <svg class="w-20 h-20 text-inactive stroke-current">
         <circle :cx="centerX" :cy="centerY" :r="radius" fill="transparent" />

--- a/src/components/forms/CheckoutStepper.vue
+++ b/src/components/forms/CheckoutStepper.vue
@@ -1,56 +1,52 @@
 <template>
-  <div class="max-w-sm m-auto bg-footer shadow-md mb-4" v-if="page < 6">
-    <div class="flex items-center p-2">
-      <div class="cursor-pointer">
-        <a @click="decrementPage" v-if="page != 1">
-          <img
-            :src="left"
-            alt="Back"
-            class="pointer-events-none w-6 h-6"
-            draggable="false"
-          />
-        </a>
-      </div>
-      <div class="flex-grow text-center">
-        <h3 class="text-2xl font-bold">{{ pageHeader }}</h3>
-      </div>
-    </div>
-    <div class="flex justify-center pb-4">
-      <div v-for="pageNum in pageCount" :key="pageNum" class="rounded-full">
-        <svg
-          class="h-4 w-4 stroke-current fill-current"
-          :class="[pageNum === page ? 'text-button' : 'text-inactive']"
+  <div class="max-w-sm m-auto bg-footer shadow-md mb-4 flex items-center">
+    <div>
+      <svg class="w-20 h-20 text-inactive stroke-current">
+        <circle :cx="centerX" :cy="centerY" :r="radius" fill="transparent" />
+        <circle
+          class="text-button stroke-current progress-bar"
+          :cx="centerX"
+          :cy="centerY"
+          :r="radius"
+          fill="transparent"
+          :stroke-dasharray="strokeDashArray"
+        />
+        <text
+          x="50%"
+          y="50%"
+          dominant-baseline="middle"
+          text-anchor="middle"
+          class="text-white text-sm fill-current stroke-0"
         >
-          <circle cx="8" cy="8" r="4" />
-        </svg>
-      </div>
+          {{ pageProgress }}
+        </text>
+      </svg>
+    </div>
+    <div class="flex-grow text-right leading-tight p-4">
+      <h3 class="text-2xl font-bold">{{ pageHeader(page) }}</h3>
+      <h4 class="text-inactive">
+        {{ pageSubheader(page) | formatPageSubHeader }}
+      </h4>
     </div>
   </div>
 </template>
 
 <script>
-import left from '@/assets/left.png';
-import { mapGetters, mapMutations } from 'vuex';
+import { mapGetters } from 'vuex';
 
 export default {
   name: 'CheckoutStepper',
   data() {
     return {
-      left,
-      pageCount: 6
+      pageCount: 5,
+      radius: 25,
+      centerX: 40,
+      centerY: 40
     };
   },
   methods: {
-    ...mapMutations('form', ['pageChange']),
-    decrementPage() {
-      const pageToGo = this.page - 1;
-      this.pageChange(pageToGo);
-    }
-  },
-  computed: {
-    ...mapGetters('form', ['page']),
-    pageHeader() {
-      switch (this.page) {
+    pageHeader(pageNum) {
+      switch (pageNum) {
         case 1: {
           return 'Customer Info';
         }
@@ -66,11 +62,49 @@ export default {
         case 5: {
           return 'Review & Order';
         }
+        case 6: {
+          return '';
+        }
         default: {
           return '';
         }
       }
+    },
+    pageSubheader(pageNum) {
+      return this.pageHeader(pageNum + 1);
+    }
+  },
+  computed: {
+    ...mapGetters('form', ['page']),
+    circumference() {
+      return 2 * Math.PI * this.radius;
+    },
+    percentageProgress() {
+      const pageProgressPercentage = this.page / this.pageCount;
+      return this.circumference * pageProgressPercentage;
+    },
+    strokeDashArray() {
+      return `${this.percentageProgress} ${this.circumference}`;
+    },
+    pageProgress() {
+      return `${this.page} of ${this.pageCount}`;
+    }
+  },
+  filters: {
+    formatPageSubHeader(subheader) {
+      return subheader ? `Next: ${subheader}` : '';
     }
   }
 };
 </script>
+
+<style scoped>
+svg {
+  transform: rotate(-90deg);
+  stroke-width: 0.25rem;
+}
+
+svg text {
+  transform: rotate(90deg) translate(0, -5rem);
+}
+</style>

--- a/src/components/forms/CheckoutStepper.vue
+++ b/src/components/forms/CheckoutStepper.vue
@@ -25,8 +25,8 @@
       </svg>
     </div>
     <div class="flex-grow text-right leading-tight p-4">
-      <h3 class="text-2xl font-bold">{{ pageHeader(page) }}</h3>
-      <h4 class="text-inactive">
+      <h3 class="text-xl md:text-2xl font-bold">{{ pageHeader(page) }}</h3>
+      <h4 class="text-base md:text-xl text-inactive">
         {{ pageSubheader(page) | formatPageSubHeader }}
       </h4>
     </div>

--- a/src/components/forms/CustomerAddress.vue
+++ b/src/components/forms/CustomerAddress.vue
@@ -37,23 +37,33 @@
       You are missing required fields, please fill out "Street Address" and
       "Town/City".
     </span>
-    <div class="w-full text-center my-4">
-      <Button title="Choose delivery time" @clicked="submit" />
+    <div class="w-full text-center my-4 flex">
+      <div
+        class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
+        @click="decrementPage"
+        v-if="page != 1"
+      >
+        ◄ Back
+      </div>
+      <div
+        class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
+        @click="submit"
+      >
+        Choose Delivery Time ►
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 import MaterialInput from '@/components/inputs/MaterialInput.vue';
-import Button from '@/components/Button.vue';
 import { mapGetters, mapMutations } from 'vuex';
 import { required } from 'vuelidate/lib/validators';
 
 export default {
   name: 'CustomerAddress',
   components: {
-    MaterialInput,
-    Button
+    MaterialInput
   },
   data() {
     return {
@@ -75,7 +85,8 @@ export default {
       'getApartment',
       'getParking',
       'getBuildingName',
-      'getStreet'
+      'getStreet',
+      'page'
     ]),
     town: {
       get() {
@@ -143,6 +154,10 @@ export default {
       } else {
         this.pageChange(3);
       }
+    },
+    decrementPage() {
+      const pageToGo = this.page - 1;
+      this.pageChange(pageToGo);
     }
   }
 };

--- a/src/components/forms/CustomerAddress.vue
+++ b/src/components/forms/CustomerAddress.vue
@@ -37,33 +37,25 @@
       You are missing required fields, please fill out "Street Address" and
       "Town/City".
     </span>
-    <div class="w-full text-center my-4 flex sticky inset-x-0 bottom-0 z-10">
-      <div
-        class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
-        @click="decrementPage"
-        v-if="page != 1"
-      >
-        ◄ Back
-      </div>
-      <div
-        class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
-        @click="submit"
-      >
-        Choose Delivery Time ►
-      </div>
-    </div>
+    <CheckoutNavBar
+      nextStepText="Pick Delivery Time ►"
+      @previousStep="decrementPage"
+      @nextStep="submit"
+    />
   </div>
 </template>
 
 <script>
 import MaterialInput from '@/components/inputs/MaterialInput.vue';
+import CheckoutNavBar from '@/components/forms/CheckoutNavBar.vue';
 import { mapGetters, mapMutations } from 'vuex';
 import { required } from 'vuelidate/lib/validators';
 
 export default {
   name: 'CustomerAddress',
   components: {
-    MaterialInput
+    MaterialInput,
+    CheckoutNavBar
   },
   data() {
     return {

--- a/src/components/forms/CustomerAddress.vue
+++ b/src/components/forms/CustomerAddress.vue
@@ -38,7 +38,7 @@
       "Town/City".
     </span>
     <CheckoutNavBar
-      nextStepText="Pick Delivery Time ►"
+      nextStepText="Set delivery time ►"
       @previousStep="decrementPage"
       @nextStep="submit"
     />

--- a/src/components/forms/CustomerAddress.vue
+++ b/src/components/forms/CustomerAddress.vue
@@ -37,7 +37,7 @@
       You are missing required fields, please fill out "Street Address" and
       "Town/City".
     </span>
-    <div class="w-full text-center my-4 flex">
+    <div class="w-full text-center my-4 flex sticky inset-x-0 bottom-0 z-10">
       <div
         class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
         @click="decrementPage"

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -35,27 +35,18 @@
     <span class="text-sm text-red-600" v-if="$v.$invalid" v-show="submitError">
       Please fill the form properly.
     </span>
-    <div class="w-full text-center my-4 flex sticky inset-x-0 bottom-0 z-10">
-      <div
-        class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
-        @click="decrementPage"
-        v-if="page != 1"
-      >
-        ◄ Back
-      </div>
-      <div
-        class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
-        @click="submit"
-      >
-        Delivery Information ►
-      </div>
-    </div>
+    <CheckoutNavBar
+      nextStepText="Delivery Info ►"
+      @previousStep="decrementPage"
+      @nextStep="submit"
+    />
   </div>
 </template>
 
 <script>
 import MaterialInput from '@/components/inputs/MaterialInput.vue';
 import TextArea from '@/components/inputs/TextArea.vue';
+import CheckoutNavBar from '@/components/forms/CheckoutNavBar.vue';
 import { mapGetters, mapMutations } from 'vuex';
 import { required, email, minLength } from 'vuelidate/lib/validators';
 
@@ -63,7 +54,8 @@ export default {
   name: 'CustomerInfo',
   components: {
     MaterialInput,
-    TextArea
+    TextArea,
+    CheckoutNavBar
   },
   data() {
     return {

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -35,8 +35,20 @@
     <span class="text-sm text-red-600" v-if="$v.$invalid" v-show="submitError">
       Please fill the form properly.
     </span>
-    <div class="w-full text-center my-4">
-      <Button title="Delivery Information" @clicked="submit" />
+    <div class="w-full text-center my-4 flex">
+      <div
+        class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
+        @click="decrementPage"
+        v-if="page != 1"
+      >
+        ◄ Back
+      </div>
+      <div
+        class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
+        @click="submit"
+      >
+        Delivery Information ►
+      </div>
     </div>
   </div>
 </template>
@@ -44,7 +56,6 @@
 <script>
 import MaterialInput from '@/components/inputs/MaterialInput.vue';
 import TextArea from '@/components/inputs/TextArea.vue';
-import Button from '@/components/Button.vue';
 import { mapGetters, mapMutations } from 'vuex';
 import { required, email, minLength } from 'vuelidate/lib/validators';
 
@@ -52,8 +63,7 @@ export default {
   name: 'CustomerInfo',
   components: {
     MaterialInput,
-    TextArea,
-    Button
+    TextArea
   },
   data() {
     return {
@@ -78,7 +88,8 @@ export default {
       'getName',
       'getEmail',
       'getPhone',
-      'getSpecialRequest'
+      'getSpecialRequest',
+      'page'
     ]),
     name: {
       get() {
@@ -128,6 +139,10 @@ export default {
       } else {
         this.pageChange(2);
       }
+    },
+    decrementPage() {
+      const pageToGo = this.page - 1;
+      this.pageChange(pageToGo);
     }
   }
 };

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -35,7 +35,7 @@
     <span class="text-sm text-red-600" v-if="$v.$invalid" v-show="submitError">
       Please fill the form properly.
     </span>
-    <div class="w-full text-center my-4 flex">
+    <div class="w-full text-center my-4 flex sticky inset-x-0 bottom-0 z-10">
       <div
         class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
         @click="decrementPage"

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -36,7 +36,7 @@
       Please fill the form properly.
     </span>
     <CheckoutNavBar
-      nextStepText="Delivery Info ►"
+      nextStepText="Add your address ►"
       @previousStep="decrementPage"
       @nextStep="submit"
     />

--- a/src/components/forms/DeliveryTime.vue
+++ b/src/components/forms/DeliveryTime.vue
@@ -62,24 +62,12 @@
         </span>
       </template>
     </Dropdown>
-    <div
-      class="w-full text-center my-4 flex sticky inset-x-0 bottom-0 z-10"
+    <CheckoutNavBar
+      nextStepText="Payment Method ►"
+      @previousStep="decrementPage"
+      @nextStep="pageChange(4)"
       v-if="option === 'Now' || timeSlots.length !== 0"
-    >
-      <div
-        class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
-        @click="decrementPage"
-        v-if="page != 1"
-      >
-        ◄ Back
-      </div>
-      <div
-        class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
-        @click="pageChange(4)"
-      >
-        Pick Payment Method ►
-      </div>
-    </div>
+    />
   </div>
 </template>
 
@@ -88,11 +76,12 @@ import RadioInput from '@/components/inputs/RadioInput';
 import Dropdown from '@/components/Dropdown.vue';
 import calendar from '@/assets/calendar.png';
 import clock from '@/assets/clock.png';
+import CheckoutNavBar from '@/components/forms/CheckoutNavBar.vue';
 import { mapMutations, mapGetters } from 'vuex';
 
 export default {
   name: 'DeliveryTime',
-  components: { RadioInput, Dropdown },
+  components: { RadioInput, Dropdown, CheckoutNavBar },
   data() {
     return {
       calendar: calendar,

--- a/src/components/forms/DeliveryTime.vue
+++ b/src/components/forms/DeliveryTime.vue
@@ -26,7 +26,7 @@
       <template #title="{ selectedOption }">
         <span v-if="selectedOption">
           {{
-            `${week[new Date(selectedOption).getDay()]} 
+            `${week[new Date(selectedOption).getDay()]}
             ${new Date(selectedOption).getDate()}`
           }}
         </span>
@@ -34,7 +34,7 @@
       <template #option="{ option }">
         <span>
           {{
-            `${week[new Date(option).getDay()]} 
+            `${week[new Date(option).getDay()]}
             ${new Date(option).getDate()}`
           }}
         </span>
@@ -62,15 +62,29 @@
         </span>
       </template>
     </Dropdown>
-    <div class="w-full text-center my-4">
-      <Button title="Pick payment method" @clicked="pageChange(4)" />
+    <div
+      class="w-full text-center my-4 flex"
+      v-if="option === 'Now' || timeSlots.length !== 0"
+    >
+      <div
+        class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
+        @click="decrementPage"
+        v-if="page != 1"
+      >
+        ◄ Back
+      </div>
+      <div
+        class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
+        @click="pageChange(4)"
+      >
+        Pick Payment Method ►
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 import RadioInput from '@/components/inputs/RadioInput';
-import Button from '@/components/Button.vue';
 import Dropdown from '@/components/Dropdown.vue';
 import calendar from '@/assets/calendar.png';
 import clock from '@/assets/clock.png';
@@ -78,7 +92,7 @@ import { mapMutations, mapGetters } from 'vuex';
 
 export default {
   name: 'DeliveryTime',
-  components: { RadioInput, Button, Dropdown },
+  components: { RadioInput, Dropdown },
   data() {
     return {
       calendar: calendar,
@@ -99,7 +113,8 @@ export default {
       'pageChange',
       'updateDeliveryDateOption',
       'updateDeliveryDateDay',
-      'updateDeliveryDateTime'
+      'updateDeliveryDateTime',
+      'pageChange'
     ]),
     millisecondToTime(duration) {
       let minutes = parseInt((duration / (1000 * 60)) % 60),
@@ -109,6 +124,10 @@ export default {
       minutes = minutes < 10 ? '0' + minutes : minutes;
 
       return hours + ':' + minutes;
+    },
+    decrementPage() {
+      const pageToGo = this.page - 1;
+      this.pageChange(pageToGo);
     }
   },
   computed: {
@@ -116,7 +135,8 @@ export default {
     ...mapGetters('form', [
       'getDeliveryDateOption',
       'getDeliveryDateDay',
-      'getDeliveryDateTime'
+      'getDeliveryDateTime',
+      'page'
     ]),
     option: {
       get() {

--- a/src/components/forms/DeliveryTime.vue
+++ b/src/components/forms/DeliveryTime.vue
@@ -63,7 +63,7 @@
       </template>
     </Dropdown>
     <div
-      class="w-full text-center my-4 flex"
+      class="w-full text-center my-4 flex sticky inset-x-0 bottom-0 z-10"
       v-if="option === 'Now' || timeSlots.length !== 0"
     >
       <div

--- a/src/components/forms/DeliveryTime.vue
+++ b/src/components/forms/DeliveryTime.vue
@@ -63,7 +63,7 @@
       </template>
     </Dropdown>
     <CheckoutNavBar
-      nextStepText="Payment Method ►"
+      nextStepText="Payment method ►"
       @previousStep="decrementPage"
       @nextStep="pageChange(4)"
       v-if="option === 'Now' || timeSlots.length !== 0"

--- a/src/components/forms/PaymentMethod.vue
+++ b/src/components/forms/PaymentMethod.vue
@@ -9,7 +9,7 @@
         class="p-5"
       />
     </div>
-    <div class="w-full text-center my-4 flex">
+    <div class="w-full text-center my-4 flex sticky inset-x-0 bottom-0 z-10">
       <div
         class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
         @click="decrementPage"

--- a/src/components/forms/PaymentMethod.vue
+++ b/src/components/forms/PaymentMethod.vue
@@ -10,7 +10,7 @@
       />
     </div>
     <CheckoutNavBar
-      nextStepText="Review & order ►"
+      nextStepText="Review your order ►"
       @previousStep="decrementPage"
       @nextStep="pageChange(5)"
     />

--- a/src/components/forms/PaymentMethod.vue
+++ b/src/components/forms/PaymentMethod.vue
@@ -9,8 +9,20 @@
         class="p-5"
       />
     </div>
-    <div class="w-full text-center my-4">
-      <Button title="Review and submit order" @clicked="pageChange(5)" />
+    <div class="w-full text-center my-4 flex">
+      <div
+        class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
+        @click="decrementPage"
+        v-if="page != 1"
+      >
+        ◄ Back
+      </div>
+      <div
+        class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
+        @click="pageChange(5)"
+      >
+        Review and order ►
+      </div>
     </div>
   </div>
 </template>
@@ -19,12 +31,11 @@
 import RadioInput from '@/components/inputs/RadioInput';
 import calendar from '@/assets/calendar.png';
 import down from '@/assets/down.png';
-import Button from '@/components/Button.vue';
 import { mapMutations, mapGetters } from 'vuex';
 
 export default {
   name: 'PaymentMethod',
-  components: { RadioInput, Button },
+  components: { RadioInput },
   data() {
     return {
       calendar: calendar,
@@ -32,10 +43,14 @@ export default {
     };
   },
   methods: {
-    ...mapMutations('form', ['pageChange', 'updatePaymentMethod'])
+    ...mapMutations('form', ['pageChange', 'updatePaymentMethod']),
+    decrementPage() {
+      const pageToGo = this.page - 1;
+      this.pageChange(pageToGo);
+    }
   },
   computed: {
-    ...mapGetters('form', ['getPaymentMethod']),
+    ...mapGetters('form', ['getPaymentMethod', 'page']),
     paymentMethod: {
       get() {
         return this.getPaymentMethod;

--- a/src/components/forms/PaymentMethod.vue
+++ b/src/components/forms/PaymentMethod.vue
@@ -9,33 +9,25 @@
         class="p-5"
       />
     </div>
-    <div class="w-full text-center my-4 flex sticky inset-x-0 bottom-0 z-10">
-      <div
-        class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
-        @click="decrementPage"
-        v-if="page != 1"
-      >
-        ◄ Back
-      </div>
-      <div
-        class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
-        @click="pageChange(5)"
-      >
-        Review and order ►
-      </div>
-    </div>
+    <CheckoutNavBar
+      nextStepText="Review & order ►"
+      @previousStep="decrementPage"
+      @nextStep="pageChange(5)"
+    />
   </div>
 </template>
 
 <script>
 import RadioInput from '@/components/inputs/RadioInput';
+import CheckoutNavBar from '@/components/forms/CheckoutNavBar.vue';
 import calendar from '@/assets/calendar.png';
+
 import down from '@/assets/down.png';
 import { mapMutations, mapGetters } from 'vuex';
 
 export default {
   name: 'PaymentMethod',
-  components: { RadioInput },
+  components: { RadioInput, CheckoutNavBar },
   data() {
     return {
       calendar: calendar,

--- a/src/components/forms/ReviewOrder.vue
+++ b/src/components/forms/ReviewOrder.vue
@@ -34,7 +34,7 @@
       </div>
       <p class=" mb-5">{{ getDeliveryTime }}</p>
     </div>
-    <div class="w-full text-center my-4 flex">
+    <div class="w-full text-center my-4 flex sticky inset-x-0 bottom-0 z-10">
       <div
         class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
         @click="decrementPage"

--- a/src/components/forms/ReviewOrder.vue
+++ b/src/components/forms/ReviewOrder.vue
@@ -34,11 +34,24 @@
       </div>
       <p class=" mb-5">{{ getDeliveryTime }}</p>
     </div>
-    <div class="w-full text-center my-4">
-      <Button title="Submit Order" @clicked="submit" />
+    <div class="w-full text-center my-4 flex">
+      <div
+        class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
+        @click="decrementPage"
+        v-if="page != 1"
+      >
+        ◄ Back
+      </div>
+      <div
+        class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
+        @clicked="submit"
+      >
+        Submit Order
+      </div>
     </div>
   </div>
 </template>
+
 <script>
 import home from '@/assets/home.png';
 import person from '@/assets/person.png';
@@ -47,14 +60,12 @@ import email from '@/assets/email.png';
 import dollar from '@/assets/dollar.png';
 import clock from '@/assets/clock.png';
 import Cart from '@/components/cart/Cart.vue';
-import Button from '@/components/Button.vue';
 import { mapGetters, mapMutations } from 'vuex';
 
 export default {
   name: 'ReviewOrder',
   components: {
-    Cart,
-    Button
+    Cart
   },
   data() {
     return {
@@ -73,7 +84,8 @@ export default {
       'getPhone',
       'getEmail',
       'getSpecialRequest',
-      'getPaymentMethod'
+      'getPaymentMethod',
+      'page'
     ]),
     getDeliveryTime() {
       return '45 Minutes';
@@ -81,6 +93,10 @@ export default {
   },
   methods: {
     ...mapMutations('form', ['pageChange']),
+    decrementPage() {
+      const pageToGo = this.page - 1;
+      this.pageChange(pageToGo);
+    },
     submit() {
       // TODO: push customer data to database
       this.pageChange(6);

--- a/src/components/forms/ReviewOrder.vue
+++ b/src/components/forms/ReviewOrder.vue
@@ -34,21 +34,11 @@
       </div>
       <p class=" mb-5">{{ getDeliveryTime }}</p>
     </div>
-    <div class="w-full text-center my-4 flex sticky inset-x-0 bottom-0 z-10">
-      <div
-        class="bg-footer w-1/3 uppercase text-left text-sm font-semibold px-4 py-4"
-        @click="decrementPage"
-        v-if="page != 1"
-      >
-        ◄ Back
-      </div>
-      <div
-        class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
-        @clicked="submit"
-      >
-        Submit Order ►
-      </div>
-    </div>
+    <CheckoutNavBar
+      nextStepText="Submit Order ►"
+      @previousStep="decrementPage"
+      @nextStep="submit"
+    />
   </div>
 </template>
 
@@ -60,12 +50,14 @@ import email from '@/assets/email.png';
 import dollar from '@/assets/dollar.png';
 import clock from '@/assets/clock.png';
 import Cart from '@/components/cart/Cart.vue';
+import CheckoutNavBar from '@/components/forms/CheckoutNavBar.vue';
 import { mapGetters, mapMutations } from 'vuex';
 
 export default {
   name: 'ReviewOrder',
   components: {
-    Cart
+    Cart,
+    CheckoutNavBar
   },
   data() {
     return {

--- a/src/components/forms/ReviewOrder.vue
+++ b/src/components/forms/ReviewOrder.vue
@@ -46,7 +46,7 @@
         class="bg-button flex-grow uppercase text-right text-sm font-semibold px-4 py-4"
         @clicked="submit"
       >
-        Submit Order
+        Submit Order ►
       </div>
     </div>
   </div>


### PR DESCRIPTION
This partially addresses Issue #97 

In this PR, we change the stepper top bar to be a circular progress bar with no navigation components. We also change the bottom progress buttons to be nav buttons allowing the user to go back.

In future PRs we will complete treating #97 with animations and other loose ends.

![image](https://user-images.githubusercontent.com/20192983/79060767-f3999780-7c3d-11ea-8497-c2dcdffe5633.png)
