### PR TITLE
chore: remove medium condition on y-margins for CheckoutNavBar component

### DIFF
--- a/src/components/forms/CheckoutNavBar.vue
+++ b/src/components/forms/CheckoutNavBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="w-full text-center md:my-4 flex sticky lg:relative inset-x-0 bottom-0 z-10"
+    class="w-full text-center my-4 flex sticky lg:relative inset-x-0 bottom-0 z-10"
   >
     <Button
       title="◄ Back"


### PR DESCRIPTION
Sometimes the CheckoutNavBar and the form portions of the component were touching, which we don't want.