### PR TITLE
refactor: moved root styling to App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,3 +11,17 @@ export default {
   name: 'App'
 };
 </script>
+
+<style>
+html,
+body {
+  scroll-behavior: smooth;
+  background-color: #003037;
+  touch-action: manipulation;
+}
+
+#app {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+</style>

--- a/src/layouts/Store.vue
+++ b/src/layouts/Store.vue
@@ -33,18 +33,6 @@ export default {
 </script>
 
 <style>
-html,
-body {
-  scroll-behavior: smooth;
-  background-color: #003037;
-  touch-action: manipulation;
-}
-
-#app {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
 .fade-enter-active {
   transition: opacity 0.3s ease;
 }


### PR DESCRIPTION
Moved `html, body` and `#app` styling to `App.vue` component as suggested in https://github.com/whynotearth/foodouken.com/pull/125#discussion_r411066753