### PR TITLE
refactor: revert to old API endpoint

### DIFF
--- a/src/store/modules/store.js
+++ b/src/store/modules/store.js
@@ -27,7 +27,7 @@ const getters = {
 const actions = {
   fetchStoreData({ commit }, slug) {
     return new Promise((resolve, reject) => {
-      httpClient.get(`/pages/slug/foodouken/${slug}/shop`).then(
+      httpClient.get(`/pages/slug/${slug}/${slug}`).then(
         response => {
           commit('loadOrgData', response.data);
           commit('loadCategories', response.data.custom.categories);


### PR DESCRIPTION
Revert API calls on Store.vue to old endpoints.

> **WARNING**: This will break the store page.