### PR TITLE
Meta: Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+# Issue Being Addressed
+
+Put the issue(s) # that your PR is addressing here. e.g. #15, #29
+
+# Type of PR
+
+Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.
+
+[ ] Bug Fix
+[ ] Refactor
+[ ] New Feature
+[ ] Update to Existing Feature
+[ ] Other (state below)
+
+# Description
+
+**For Bug Fixes:** What was the root cause? How do your changes fix the bug effectively?
+
+**For Refactors:** What are we refactoring and why? How do your changes address this need for refactoring?
+
+**For New Features:** What feature are we adding? Explain your technical approach to doing this.
+
+**For Feature Updates:** What feature are we updating? Explain your technical approach to doing this.
+
+**For Other:** State what 'type' of PR yours is and elaborate on the PR's technical content.
+
+# How to Test/Reproduce
+
+Provide steps on how one can test your changes here. e.g.
+1. Log in as '...'
+2. Go to '...'
+3. Click on '...'
+4. See the updated element x
+
+# Screenshots/casts
+
+If applicable, include any relevant screenshot or screencasts of your changes.
+
+# Additional Context
+
+Provide any additional notes that you think would help effective review of your code.


### PR DESCRIPTION
This adds a template that will auto-populate the 'description' section every time someone creates a GitHub PR in the repo. Then, the PR opener can just fill it out. This will eliminate the need to copy and paste the template every time from some other source.

(Copy and pasted from BrowTricks PR for adding template: Adding such a template should help PR descriptions be more focused and thorough which should help produce faster and more effective reviews which should help the codebase be more navigable, extendable, rack up less tech debt, etc., etc.)

Some small changes from the template originally from BrowTricks:

* the 'type of pr' section is no longer a 'task list' in the GitHub markdown format, as GitHub treats those as literal task lists and displays them in the repo's PR list like so, which may confuse some people:
  
  ![image](https://user-images.githubusercontent.com/20192983/83690792-42144400-a5a6-11ea-878a-9f4bde25de16.png)

* bold instead of italicize subsections for the 'description' section

* add a "For Other" subsection for the 'description' section to give room for people opening unique PRs to provide an explanation