### PR TITLE
Feat/My Account, tenantLayout, safety checks for tenants, route to Account on login.

### DIFF
--- a/src/components/BaseAppBarHeader.vue
+++ b/src/components/BaseAppBarHeader.vue
@@ -6,7 +6,11 @@
           <img :src="arrowBack" />
         </router-link>
       </div>
-      <div class="text-white font-bold text-xl truncate">{{ title }}</div>
+      <transition name="fade" mode="out-in">
+        <div :key="title" class="text-white font-bold text-xl truncate">
+          {{ title }}
+        </div>
+      </transition>
       <!-- The action only has routing -->
       <router-link
         v-if="action && !action.method"

--- a/src/components/menu/MenuItem.vue
+++ b/src/components/menu/MenuItem.vue
@@ -8,7 +8,7 @@
         :src="image"
         class="object-cover h-full w-full"
         draggable="false"
-        alt="item"
+        alt="img"
       />
     </div>
     <div class="mx-2 w-full flex flex-col truncate z-10">

--- a/src/router/authRoutes.js
+++ b/src/router/authRoutes.js
@@ -24,7 +24,7 @@ export const authRoutes = [
         .dispatch('auth/ping')
         .then(response => {
           if (response.isAuthenticated) {
-            next({ name: 'Home' });
+            next({ name: 'Account' });
           } else {
             throw new Error('USER_NOT_LOGGED_IN');
           }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,18 +9,10 @@ import { settingRoutes } from './settingRoutes';
 
 Vue.use(VueRouter);
 
-// If you use prefixRoutes function, make sure that your child routes start with a '/'
-function prefixRoutes(prefix, routes) {
-  return routes.map(route => {
-    route.path = prefix + '' + route.path;
-    return route;
-  });
-}
-
 const routes = [
   ...customerViewRoutes,
   ...settingRoutes,
-  ...prefixRoutes('/tenant/:tenantSlug/menu', [...tenantCMSRoutes]),
+  ...tenantCMSRoutes,
   ...authRoutes,
   {
     path: '/*',

--- a/src/router/tenantCMSRoutes.js
+++ b/src/router/tenantCMSRoutes.js
@@ -29,6 +29,24 @@ export const tenantCMSRoutes = [
         path: 'categories',
         name: 'MenuCategoryList',
         component: () => import('@/views/MenuCategoryList.vue'),
+        beforeEnter: (to, from, next) => {
+          if (to.params.tenant) {
+            to.meta.appBar.title = to.params.tenant.name;
+            next();
+          } else {
+            store
+              .dispatch('shop/fetchShopData', to.params.tenantSlug)
+              .then(tenant => {
+                to.meta.appBar.title = tenant.name;
+                next();
+              })
+              .catch(error => {
+                to.meta.appBar.title = 'Categories';
+                next();
+                throw new Error(error);
+              });
+          }
+        },
         meta: {
           layout: () => import('@/layouts/TenantLayout.vue'),
           requiresAuth: true,

--- a/src/router/tenantCMSRoutes.js
+++ b/src/router/tenantCMSRoutes.js
@@ -10,7 +10,7 @@ export const tenantCMSRoutes = [
       requiresAuth: true,
       appBar: {
         title: 'Categories',
-        backRoute: { name: 'Home' },
+        backRoute: { name: 'Account' },
         newItem: { name: 'MenuCategoryAdd' }
       }
     }

--- a/src/router/tenantCMSRoutes.js
+++ b/src/router/tenantCMSRoutes.js
@@ -88,21 +88,26 @@ export const tenantCMSRoutes = [
         name: 'MenuItemList',
         component: () => import('@/views/MenuItemList.vue'),
         beforeEnter: (to, from, next) => {
-          let params = {
-            tenantSlug: to.params.tenantSlug,
-            categoryId: to.params.categoryId
-          };
-          store
-            .dispatch('menu/fetchTenantCategoryById', params)
-            .then(category => {
-              to.meta.appBar.title = category.name;
-              next();
-            })
-            .catch(error => {
-              to.meta.appBar.title = 'Category';
-              next();
-              throw new Error(error.message);
-            });
+          if (to.params.category) {
+            to.meta.appBar.title = to.params.category.name;
+            next();
+          } else {
+            let params = {
+              tenantSlug: to.params.tenantSlug,
+              categoryId: to.params.categoryId
+            };
+            store
+              .dispatch('menu/fetchTenantCategoryById', params)
+              .then(category => {
+                to.meta.appBar.title = category.name;
+                next();
+              })
+              .catch(error => {
+                to.meta.appBar.title = 'Category';
+                next();
+                throw new Error(error.message);
+              });
+          }
         },
         meta: {
           layout: () => import('@/layouts/TenantLayout.vue'),
@@ -142,5 +147,9 @@ export const tenantCMSRoutes = [
         }
       }
     ]
+  },
+  {
+    path: '/tenant/:tenantSlug/menu',
+    redirect: '/tenant/:tenantSlug/menu/categories'
   }
 ];

--- a/src/router/tenantCMSRoutes.js
+++ b/src/router/tenantCMSRoutes.js
@@ -5,6 +5,25 @@ export const tenantCMSRoutes = [
     path: '/tenant/:tenantSlug/menu',
     name: 'Menu',
     component: () => import('@/views/Menu.vue'),
+    beforeEnter: (to, from, next) => {
+      if (from.name === 'Account') next();
+      else {
+        store
+          .dispatch('tenant/userOwnsTenant', to.params.tenantSlug)
+          .then(result => {
+            if (result) {
+              next();
+            } else {
+              next({ name: 'Account' });
+              alert('You do not have permission to access this tenant!');
+            }
+          })
+          .catch(error => {
+            next({ name: 'Account' });
+            throw new Error(error);
+          });
+      }
+    },
     children: [
       {
         path: 'categories',

--- a/src/router/tenantCMSRoutes.js
+++ b/src/router/tenantCMSRoutes.js
@@ -2,101 +2,108 @@ import store from '@/store';
 
 export const tenantCMSRoutes = [
   {
-    path: '/categories',
-    name: 'MenuCategoryList',
-    component: () => import('@/views/MenuCategoryList.vue'),
-    meta: {
-      layout: () => import('@/layouts/TenantLayout.vue'),
-      requiresAuth: true,
-      appBar: {
-        title: 'Categories',
-        backRoute: { name: 'Account' },
-        newItem: { name: 'MenuCategoryAdd' }
-      }
-    }
-  },
-  {
-    path: '/categories/add',
-    name: 'MenuCategoryAdd',
-    component: () => import('@/views/MenuCategoryAddEdit.vue'),
-    meta: {
-      layout: () => import('@/layouts/TenantLayout.vue'),
-      requiresAuth: true,
-      appBar: {
-        title: 'Add new category',
-        backRoute: { name: 'MenuCategoryList' }
-      }
-    }
-  },
-  {
-    path: '/categories/:categoryId/edit',
-    name: 'MenuCategoryEdit',
-    component: () => import('@/views/MenuCategoryAddEdit.vue'),
-    meta: {
-      layout: () => import('@/layouts/TenantLayout.vue'),
-      requiresAuth: true,
-      appBar: {
-        title: 'Edit category',
-        backRoute: { name: 'MenuCategoryList' }
-      }
-    }
-  },
-  {
-    path: '/categories/:categoryId/items',
-    name: 'MenuItemList',
-    component: () => import('@/views/MenuItemList.vue'),
-    beforeEnter: (to, from, next) => {
-      let params = {
-        tenantSlug: to.params.tenantSlug,
-        categoryId: to.params.categoryId
-      };
-      store
-        .dispatch('menu/fetchTenantCategoryById', params)
-        .then(category => {
-          to.meta.appBar.title = category.name;
-          next();
-        })
-        .catch(error => {
-          to.meta.appBar.title = 'Category';
-          next();
-          throw new Error(error.message);
-        });
-    },
-    meta: {
-      layout: () => import('@/layouts/TenantLayout.vue'),
-      requiresAuth: true,
-      appBar: {
-        backRoute: { name: 'MenuCategoryList' },
-        newItem: { name: 'MenuItemAdd' }
-      }
-    }
-  },
-  {
-    path: '/categories/:categoryId/items/add',
-    name: 'MenuItemAdd',
-    component: () => import('@/views/MenuItemAddEdit.vue'),
-    meta: {
-      layout: () => import('@/layouts/TenantLayout.vue'),
-      requiresAuth: true,
-      appBar: {
-        title: 'Add new item',
-        backRoute: { name: 'MenuItemList' }
-      }
-    }
-  },
-  {
-    path: '/categories/:categoryId/items/:item/edit',
-    name: 'MenuItemEdit',
-    component: () => import('@/views/MenuItemAddEdit.vue'),
-    meta: {
-      layout: () => import('@/layouts/TenantLayout.vue'),
-      requiresAuth: true,
-      appBar: {
-        title: 'Edit item',
-        backRoute: {
-          name: 'MenuItemList'
+    path: '/tenant/:tenantSlug/menu',
+    name: 'Menu',
+    component: () => import('@/views/Menu.vue'),
+    children: [
+      {
+        path: 'categories',
+        name: 'MenuCategoryList',
+        component: () => import('@/views/MenuCategoryList.vue'),
+        meta: {
+          layout: () => import('@/layouts/TenantLayout.vue'),
+          requiresAuth: true,
+          appBar: {
+            title: 'Categories',
+            backRoute: { name: 'Account' },
+            newItem: { name: 'MenuCategoryAdd' }
+          }
+        }
+      },
+      {
+        path: 'categories/add',
+        name: 'MenuCategoryAdd',
+        component: () => import('@/views/MenuCategoryAddEdit.vue'),
+        meta: {
+          layout: () => import('@/layouts/TenantLayout.vue'),
+          requiresAuth: true,
+          appBar: {
+            title: 'Add new category',
+            backRoute: { name: 'MenuCategoryList' }
+          }
+        }
+      },
+      {
+        path: 'categories/:categoryId/edit',
+        name: 'MenuCategoryEdit',
+        component: () => import('@/views/MenuCategoryAddEdit.vue'),
+        meta: {
+          layout: () => import('@/layouts/TenantLayout.vue'),
+          requiresAuth: true,
+          appBar: {
+            title: 'Edit category',
+            backRoute: { name: 'MenuCategoryList' }
+          }
+        }
+      },
+      {
+        path: 'categories/:categoryId/items',
+        name: 'MenuItemList',
+        component: () => import('@/views/MenuItemList.vue'),
+        beforeEnter: (to, from, next) => {
+          let params = {
+            tenantSlug: to.params.tenantSlug,
+            categoryId: to.params.categoryId
+          };
+          store
+            .dispatch('menu/fetchTenantCategoryById', params)
+            .then(category => {
+              to.meta.appBar.title = category.name;
+              next();
+            })
+            .catch(error => {
+              to.meta.appBar.title = 'Category';
+              next();
+              throw new Error(error.message);
+            });
+        },
+        meta: {
+          layout: () => import('@/layouts/TenantLayout.vue'),
+          requiresAuth: true,
+          appBar: {
+            backRoute: { name: 'MenuCategoryList' },
+            newItem: { name: 'MenuItemAdd' }
+          }
+        }
+      },
+      {
+        path: 'categories/:categoryId/items/add',
+        name: 'MenuItemAdd',
+        component: () => import('@/views/MenuItemAddEdit.vue'),
+        meta: {
+          layout: () => import('@/layouts/TenantLayout.vue'),
+          requiresAuth: true,
+          appBar: {
+            title: 'Add new item',
+            backRoute: { name: 'MenuItemList' }
+          }
+        }
+      },
+      {
+        path: 'categories/:categoryId/items/:item/edit',
+        name: 'MenuItemEdit',
+        component: () => import('@/views/MenuItemAddEdit.vue'),
+        meta: {
+          layout: () => import('@/layouts/TenantLayout.vue'),
+          requiresAuth: true,
+          appBar: {
+            title: 'Edit item',
+            backRoute: {
+              name: 'MenuItemList'
+            }
+          }
         }
       }
-    }
+    ]
   }
 ];

--- a/src/store/modules/tenant.js
+++ b/src/store/modules/tenant.js
@@ -135,6 +135,21 @@ const actions = {
         }
       );
     });
+  },
+  userOwnsTenant(context, tenantSlug) {
+    let companySlug = process.env.VUE_APP_COMPANY_SLUG;
+    return new Promise((resolve, reject) => {
+      httpClient
+        .get(`/companies/${companySlug}/tenants/owns/${tenantSlug}`)
+        .then(
+          response => {
+            resolve(response.data);
+          },
+          error => {
+            reject(error);
+          }
+        );
+    });
   }
 };
 

--- a/src/store/modules/tenant.js
+++ b/src/store/modules/tenant.js
@@ -122,6 +122,19 @@ const actions = {
           }
         );
     });
+  },
+  fetchUserTenants() {
+    let companySlug = process.env.VUE_APP_COMPANY_SLUG;
+    return new Promise((resolve, reject) => {
+      httpClient.get(`/companies/${companySlug}/tenants/mytenants`).then(
+        response => {
+          resolve(response.data);
+        },
+        error => {
+          reject(error);
+        }
+      );
+    });
   }
 };
 

--- a/src/views/Menu.vue
+++ b/src/views/Menu.vue
@@ -1,40 +1,27 @@
 <template>
-  <div class="mx-auto">
-    <BaseAppBarHeader :title="appBar.title" :toLink="appBar.backRoute">
-      <template #menu v-if="appBar.newItem">
-        <div class="flex-grow inline-block text-right">
-          <router-link :to="appBar.newItem" class="relative">
-            <NewItemIcon class="float-right w-5 h-5 my-auto cursor-pointer" />
-          </router-link>
-        </div>
-      </template>
-    </BaseAppBarHeader>
-    <transition name="fade" mode="out-in">
-      <router-view class="container mx-auto"></router-view>
-    </transition>
-  </div>
+  <transition name="fade" mode="out-in">
+    <router-view />
+  </transition>
 </template>
 
 <script>
-import BaseAppBarHeader from '@/components/BaseAppBarHeader';
-import NewItemIcon from '@/assets/new_item.svg';
-
 export default {
   name: 'Menu',
-  components: {
-    BaseAppBarHeader,
-    NewItemIcon
-  },
-  computed: {
-    appBar() {
-      let route = this.$route,
-        appBarData = {
-          title: 'Navbar',
-          backRoute: { name: 'Home' }
-        };
-      if (route.meta.appBar) appBarData = route.meta.appBar;
-      return appBarData;
-    }
+  created() {
+    this.$store
+      .dispatch('tenant/userOwnsTenant', this.$route.params.tenantSlug)
+      .then(result => {
+        if (result) {
+          this.$router.push({ name: 'MenuCategoryList' });
+        } else {
+          this.$router.push({ name: 'Account' });
+          alert('You do not have permission to access this tenant!');
+        }
+      })
+      .catch(error => {
+        this.$router.push({ name: 'Account' });
+        throw new Error(error);
+      });
   }
 };
 </script>

--- a/src/views/Menu.vue
+++ b/src/views/Menu.vue
@@ -6,22 +6,6 @@
 
 <script>
 export default {
-  name: 'Menu',
-  created() {
-    this.$store
-      .dispatch('tenant/userOwnsTenant', this.$route.params.tenantSlug)
-      .then(result => {
-        if (result) {
-          this.$router.push({ name: 'MenuCategoryList' });
-        } else {
-          this.$router.push({ name: 'Account' });
-          alert('You do not have permission to access this tenant!');
-        }
-      })
-      .catch(error => {
-        this.$router.push({ name: 'Account' });
-        throw new Error(error);
-      });
-  }
+  name: 'Menu'
 };
 </script>

--- a/src/views/MenuCategoryList.vue
+++ b/src/views/MenuCategoryList.vue
@@ -9,7 +9,7 @@
       :name="category.name"
       :image="category.imageUrl"
       :options="menuItemOptions"
-      @clicked="showItems(category.id)"
+      @clicked="showItems(category)"
       @edit="editCategory(category.id)"
       @delete="deleteCategory(category)"
     />
@@ -54,10 +54,10 @@ export default {
   methods: {
     ...mapMutations('menu', ['updateCategories']),
     ...mapActions('menu', ['fetchTenantCategories', 'deleteTenantCategory']),
-    showItems(categoryId) {
+    showItems(category) {
       this.$router.push({
         name: 'MenuItemList',
-        params: { categoryId: categoryId }
+        params: { categoryId: category.id, category: category }
       });
     },
     async onSuccessSubmit() {

--- a/src/views/MenuCategoryList.vue
+++ b/src/views/MenuCategoryList.vue
@@ -18,7 +18,7 @@
 
 <script>
 import MenuItem from '@/components/menu/MenuItem';
-import { mapActions, mapGetters } from 'vuex';
+import { mapActions, mapGetters, mapMutations } from 'vuex';
 import { sleep } from '@/helpers.js';
 
 export default {
@@ -45,10 +45,14 @@ export default {
   created() {
     this.fetchTenantCategories(this.tenantSlug);
   },
+  beforeDestroy() {
+    this.updateCategories([]);
+  },
   computed: {
     ...mapGetters('menu', ['getCategories'])
   },
   methods: {
+    ...mapMutations('menu', ['updateCategories']),
     ...mapActions('menu', ['fetchTenantCategories', 'deleteTenantCategory']),
     showItems(categoryId) {
       this.$router.push({

--- a/src/views/SettingsAccount.vue
+++ b/src/views/SettingsAccount.vue
@@ -10,8 +10,8 @@
       class="grid grid-cols-1 md:grid-cols-3 gap-4 my-4"
     >
       <div
-        v-for="(tenant, index) in tenants"
-        :key="index"
+        v-for="tenant in tenants"
+        :key="tenant.slug"
         class="shadow-1dp bg-secondary rounded-lg p-2 max-w-sm"
       >
         <MenuItem

--- a/src/views/SettingsAccount.vue
+++ b/src/views/SettingsAccount.vue
@@ -17,7 +17,7 @@
         <MenuItem
           :name="tenant.name"
           :image="tenant.logoUrl"
-          @clicked="manageTenant(tenant.slug)"
+          @clicked="manageTenant(tenant)"
         >
           <template #subHeading>
             Foodouken
@@ -62,10 +62,10 @@ export default {
           throw error;
         });
     },
-    manageTenant(tenantSlug) {
+    manageTenant(tenant) {
       this.$router.push({
         name: 'MenuCategoryList',
-        params: { tenantSlug: tenantSlug }
+        params: { tenantSlug: tenant.slug, tenant: tenant }
       });
     }
   }

--- a/src/views/SettingsAccount.vue
+++ b/src/views/SettingsAccount.vue
@@ -4,7 +4,11 @@
     <span v-if="apiError" class="my-8 mx-4 text-sm text-red-600">
       {{ apiError }}
     </span>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 my-4">
+    <transition-group
+      name="fade"
+      mode="out-in"
+      class="grid grid-cols-1 md:grid-cols-3 gap-4 my-4"
+    >
       <div
         v-for="(tenant, index) in tenants"
         :key="index"
@@ -20,7 +24,7 @@
           </template>
         </MenuItem>
       </div>
-    </div>
+    </transition-group>
   </div>
 </template>
 

--- a/src/views/SettingsAccount.vue
+++ b/src/views/SettingsAccount.vue
@@ -1,9 +1,69 @@
 <template>
-  <div></div>
+  <div class="p-4">
+    <h3 class="tg-h3-mobile text-white text-opacity-84">Business Management</h3>
+    <span v-if="apiError" class="my-8 mx-4 text-sm text-red-600">
+      {{ apiError }}
+    </span>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 my-4">
+      <div
+        v-for="(tenant, index) in tenants"
+        :key="index"
+        class="shadow-1dp bg-secondary rounded-lg p-2 max-w-sm"
+      >
+        <MenuItem
+          :name="tenant.name"
+          :image="tenant.logoUrl"
+          @clicked="manageTenant(tenant.slug)"
+        >
+          <template #subHeading>
+            Foodouken
+          </template>
+        </MenuItem>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
-export default {};
-</script>
+import MenuItem from '@/components/menu/MenuItem';
+import { mapActions } from 'vuex';
 
-<style></style>
+export default {
+  name: 'SettingsAccount',
+  components: { MenuItem },
+  data() {
+    return {
+      apiError: '',
+      tenants: []
+    };
+  },
+  created() {
+    this.init();
+  },
+  beforeDestroy() {
+    this.tenants = [];
+    this.apiError = '';
+  },
+  methods: {
+    ...mapActions('tenant', ['fetchUserTenants']),
+    init() {
+      this.fetchUserTenants()
+        .then(tenants => {
+          this.tenants = tenants;
+        })
+        .catch(error => {
+          this.apiError = error.response.data.title
+            ? error.response.data.title
+            : 'Something went wrong, try again.';
+          throw error;
+        });
+    },
+    manageTenant(tenantSlug) {
+      this.$router.push({
+        name: 'MenuCategoryList',
+        params: { tenantSlug: tenantSlug }
+      });
+    }
+  }
+};
+</script>


### PR DESCRIPTION
# Issue Being Addressed
#258, tenantSlug safety checks and other bugs.

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] Bug Fix
[x] Refactor
[x] New Feature
[x] Update to Existing Feature
[ ] Other (state below)

# Description

**For Bug Fixes:** What was the root cause? How do your changes fix the bug effectively?
- Bug in categoryList view, data related to old categories not cleared on component destroyed.
- Made "3 dot menu" optional in MenuItem
- Fixed layout of Settings.vue
- Fixed text styles of Settings.vue

**For Refactors:** What are we refactoring and why? How do your changes address this need for refactoring?
- Menu.vue has been made more minimal.
- tenantLayout.vue has been made a master layout with BaseAppBarHeader
- removed redundant BaseAppBarHeader from Settings.vue
- reverted tenantCMSRoutes to old pattern
- removed prefixRoutes func

**For New Features:** What feature are we adding? Explain your technical approach to doing this.
- Built My Account view
- added fetchUserTenants
- added userOwnsTenant Action

**For Feature Updates:** What feature are we updating? Explain your technical approach to doing this.
- Added more transitions to smooth out general navigation.
- take user to Account page when authed
- changed alt text for image in menuItem
- backRoute from categoryList takes user to Account Management

**For Other:** State what 'type' of PR yours is and elaborate on the PR's technical content.

# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.
1. Go to https://deploy-preview-262--foodouken.netlify.app/welcome
2. Log in/Sig up
3. You'll be taken to MyAccount view
4. Click on any Tenant to manage.
5. You'll see the name of the tenant on the BaseAppBarHeader

Alternatively, try using any arbitrary tenant's slug and see if it takes you to view it's categories and items.

# Screenshots/casts

If applicable, include any relevant screenshot or screen casts of your changes.

Settings page layout and styles fixed
![image](https://user-images.githubusercontent.com/34229217/86020598-bd520400-ba45-11ea-939e-39eecd65e45d.png)

My Account page
![image](https://user-images.githubusercontent.com/34229217/86020560-b2976f00-ba45-11ea-9df6-45dcfd9c829a.png)

Tenant not of the user
![image](https://user-images.githubusercontent.com/34229217/86022885-947f3e00-ba48-11ea-9e94-6a0b2202cea4.png)

Tenant name on category list
![image](https://user-images.githubusercontent.com/34229217/86024540-be396480-ba4a-11ea-931b-2b999479f3f2.png)


# Additional Context

Provide any additional notes that you think would help effective review of your code.

- The API is called to check if tenant belongs to owner only if the user is directly using the link to reach the page, if he's coming from his own My Account view, check is not necessary.

- The Tenant endpoint is called to display the name of the tenant in the category list page only when the user is coming directly to the link, else the tenant object is sent as param.

- The category is fetched by Id only when coming from an external link in case of displaying the category name on menu items list.