### PR TITLE
Added savedPosition when going back a page

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -45,4 +45,19 @@ router.beforeEach((to, from, next) => {
     });
 });
 
+router.options.scrollBehavior = function(to, from , savedPosition) {
+  if (savedPosition) {
+    //if going to the previous page with the back button or left swipe on mobile you are on the content you were last viewing
+    return savedPosition
+ }
+ if (to.hash) {
+   //prevent the page from scrolling up when someone clicks "Order Now"
+   if (document.URL.indexOf("/shop/") != -1) {
+     //if were not on the /shop/ page then scroll to top of page on next view
+     return { selector: to.hash }
+   }
+  }
+  return { x: 0, y: 0 }
+}
+
 export default router;


### PR DESCRIPTION
Added scrollToTop on new page

# Issue Being Addressed

No issue on record. When you are scrolled down the page and click a tenant you're viewport is at the same scroll distance from the top. A better experience would be to automatically scroll to top of page on a new router view.

# Type of PR

[x] New Feature

# Description

Improve UX by having the app scroll to top when a user excepts it to and retain the last place they were viewing when going to a previous page.

# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.
Currently this happens:
1. Go to https://foodouken.com/
2. Scroll down to tenants and click any tenant. Notice page scrolls to top
3. Click back via Web Browser button or swipe left on mobile
4. Scroll down to tenants again and click any tenant
5. Notice the page does not scroll to top automatically the second time.

This will happen with the PR:
1. Go to https://deploy-preview-305--foodouken.netlify.app/
2. Scroll down to tenants and click any tenant
3. Click back via Web Browser button or swipe left on mobile
4. Scroll down to tenants again and click any tenant
5. Scroll down to tenants and click any tenant. Notice page scrolls to top again

