### PR TITLE
Added impression datalayer to use with Google Enhanced eCommerce

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import VueMeta from 'vue-meta';
 import SmoothPicker from 'vue-smooth-picker';
 import 'vue-smooth-picker/dist/css/style.css';
 import vClickOutside from 'v-click-outside';
-
+var dataLayer = dataLayer || [];
 require('typeface-open-sans');
 
 Vue.use(SmoothPicker);

--- a/src/store/modules/home.js
+++ b/src/store/modules/home.js
@@ -67,6 +67,24 @@ const mutations = {
   },
   loadTenants(state, payload) {
     state.tenants = payload;
+    /* Start Impression Datalayer for future use */
+    var impressionArr = [];
+    payload.forEach(function (value, i) {
+       impressionArr.push({
+          id: value.slug,
+          name: value.name,
+          list: "homepage",
+          position: i+1
+      });
+    });
+    window.dataLayer.push({
+      'ecommerce': {
+        'currencyCode': 'USD',
+        'impressions': [
+          impressionArr
+        ]
+      }
+    });
   },
   changeHomeLoading(state, payload) {
     state.loading = payload;


### PR DESCRIPTION
# Issue Being Addressed

No issue

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] New Feature

# Description

Updating dataLayer for Google Enhanced eCommerce to know what position the tenants are loading at.

# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.
1. Download https://chrome.google.com/webstore/detail/dataslayer/ikbablmmjldhamhcldjjigniffkkjgpo?hl=en-US
2. Open the extension and make sure you are in 'json' view
3. Go to https://deploy-preview-307--foodouken.netlify.app/ and open DataSlayer to test it

# Screenshots/casts
https://i.imgur.com/aNz2sfH.png

# Additional Context

This is just a start. It will be used properly in the future, with Meredith Core