### PR TITLE
Big number input on phone software keyboards

### DIFF
--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -31,7 +31,7 @@
       <material-input
         v-model="$v.phone.$model"
         label="Phone number"
-        type="number"
+        type="tel"
         pattern='pattern="[0-9]*'
         :error="$v.phone.$dirty && (!$v.phone.required || !$v.phone.minLength)"
       >

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -31,6 +31,8 @@
       <material-input
         v-model="$v.phone.$model"
         label="Phone number"
+        type="number"
+        pattern='pattern="[0-9]*'
         :error="$v.phone.$dirty && (!$v.phone.required || !$v.phone.minLength)"
       >
         <span

--- a/src/components/inputs/MaterialInput.vue
+++ b/src/components/inputs/MaterialInput.vue
@@ -14,6 +14,7 @@
       :step="step"
       :value="value"
       @blur="$emit('input', $event.target.value)"
+      :pattern="pattern"
       :placeholder="placeholder || label"
     />
     <label
@@ -42,6 +43,9 @@ export default {
       default: 'Label'
     },
     placeholder: {
+      type: String
+    },
+    pattern: {
       type: String
     },
     type: {


### PR DESCRIPTION
# Issue Being Addressed

None.

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] Update to Existing Feature

# Description

Desktop still functions the same way for phone number input, but now its easier to enter on mobile.


# How to Test/Reproduce

Steps to reproduce bad UX on current site:
1. Go to start an order on https://foodouken.com/ with a mobile device
2. Notice in phone number field you can input text
3. ![IMG_7914](https://user-images.githubusercontent.com/44442621/87003257-4b866280-c189-11ea-8f3c-c8154348b255.png)

THE FIX:
1. Go to start an order on https://deploy-preview-316--foodouken.netlify.app/ with a mobile device
2. Notice in phone number field you have big number buttons on the software keyboard
3. ![IMG_7917](https://user-images.githubusercontent.com/44442621/87003341-707ad580-c189-11ea-973e-46675e239415.png)

# Additional Context

This gives a better UX.