### PR TITLE
Remove trailing and leading whitespaces

### DIFF
--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -31,7 +31,7 @@
       <material-input
         v-model="$v.phone.$model"
         label="Phone number"
-        type="number"
+        type="tel"
         pattern='pattern="[0-9]*'
         :error="$v.phone.$dirty && (!$v.phone.required || !$v.phone.minLength)"
       >

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -31,6 +31,8 @@
       <material-input
         v-model="$v.phone.$model"
         label="Phone number"
+        type="number"
+        pattern='pattern="[0-9]*'
         :error="$v.phone.$dirty && (!$v.phone.required || !$v.phone.minLength)"
       >
         <span

--- a/src/components/inputs/MaterialInput.vue
+++ b/src/components/inputs/MaterialInput.vue
@@ -14,6 +14,7 @@
       :step="step"
       :value="value"
       @blur="$emit('input', $event.target.value)"
+      :pattern="pattern"
       :placeholder="placeholder || label"
     />
     <label
@@ -42,6 +43,9 @@ export default {
       default: 'Label'
     },
     placeholder: {
+      type: String
+    },
+    pattern: {
       type: String
     },
     type: {

--- a/src/components/inputs/MaterialInput.vue
+++ b/src/components/inputs/MaterialInput.vue
@@ -12,7 +12,7 @@
       :type="type"
       min="0"
       :step="step"
-      :value="value"
+      :value="value | trim"
       @blur="$emit('input', $event.target.value)"
       :pattern="pattern"
       :placeholder="placeholder || label"
@@ -65,6 +65,11 @@ export default {
     },
     labelBg: {
       type: String
+    }
+  },
+  filters: {
+    trim: function(string) {
+      return string.trim()
     }
   }
 };


### PR DESCRIPTION
# Issue Being Addressed

#302

# Type of PR

[x] Bug Fix

# Description

Its possible leading and trailing whitespaces can cause issues with API calls. This PR removes trailing and leading whitespaces on all <input> fields, but not <textarea> or <select> etc...

# How to Test/Reproduce

### Provide steps on how one can test your changes here. e.g.
1. Go to https://foodouken.com/
2. Click any tenant
3. Order an item and fill in text with leading and trailing spaces
4. Notice when you submit the form your spaces are still there

### This PR works like this:
Provide steps on how one can test your changes here. e.g.
1. Go to https://deploy-preview-317--foodouken.netlify.app/
2. Click any tenant
3. Order an item and fill in text with leading and trailing spaces. Notice you can still input the spaces but once you unfocus the field then the trailing and leading spaces are trimmed.


