### PR TITLE
Remove leading and trailing white spaces on all input fields

### DIFF
--- a/src/components/inputs/MaterialInput.vue
+++ b/src/components/inputs/MaterialInput.vue
@@ -62,6 +62,11 @@ export default {
     labelBg: {
       type: String
     }
+  },
+  filters: {
+    trim: function(string) {
+      return string.trim();
+    }
   }
 };
 </script>


### PR DESCRIPTION
# Issue Being Addressed

#302

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] Bug Fix

# Description

**For Bug Fixes:** Its possible leading and trailing whitespaces can cause issues with API calls. This PR removes trailing and leading whitespaces on all fields, but not <textarea> or etc...



# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.
1. Go to https://foodouken.com/ 
2. Click any tenant Order an item and fill in text with leading and trailing spaces
3. Notice when you submit the form your spaces are still there

The fix:
1. Go to https://deploy-preview-317--foodouken.netlify.app/
2. Click any tenant Order an item and fill in text with leading and trailing spaces
3. Notice you can still input the spaces but once you unfocus the field then the trailing and leading spaces are trimmed.


# Screenshots/casts

If applicable, include any relevant screenshot or screencasts of your changes.

# Additional Context

Provide any additional notes that you think would help effective review of your code.