### PR TITLE
Created a small cookie utility and added X svg button to dismiss banner

### DIFF
--- a/src/components/BaseSiteBanner.vue
+++ b/src/components/BaseSiteBanner.vue
@@ -1,18 +1,37 @@
 <template>
-  <div v-if="showBanner"
-    class="top-0 w-full z-100"
-    :class="
-      backdrop ? 'fixed h-screen w-screen bg-black bg-opacity-54' : 'sticky'
-    "
+<transition
+      enter-active-class="transition ease-out duration-200 transform"
+      enter-class="opacity-0 scale-95"
+      enter-to-class="opacity-100 scale-100"
+      leave-active-class="transition ease-in duration-150 transform"
+      leave-class="opacity-100 scale-100"
+      leave-to-class="opacity-0 scale-95"
   >
-    <div
-      class="p-2 text-center tg-body-mobile-bold md:tg-desktop-bolded-caption"
-      :class="background"
+    <div v-if="showBanner"
+      class="top-0 w-full z-100"
+      :class="
+        backdrop ? 'fixed h-screen w-screen bg-black bg-opacity-54' : 'sticky'
+      "
     >
-      <slot>Site Banner</slot>
+      <div
+        class="p-2 text-center tg-body-mobile-bold md:tg-desktop-bolded-caption"
+        :class="background"
+      >
+        <slot>Site Banner</slot>
+      </div>
+      <svg 
+        @click="setBannerCookie()"
+        class="absolute top-0 right-0 md:mt-2 mr-1 md:mr-2 h-8 w-8 cursor-pointer hover:bg-red-500 hover:rounded"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        stroke="currentColor">
+          <path d="M6 18L18 6M6 6l12 12" />
+      </svg>
     </div>
-    <svg @click="setBannerCookie()" class="absolute top-0 right-0 h-8 w-8 cursor-pointer" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" stroke="currentColor"><path d="M6 18L18 6M6 6l12 12"></path></svg>
-  </div>
+</transition>
 </template>
 
 <script>

--- a/src/components/BaseSiteBanner.vue
+++ b/src/components/BaseSiteBanner.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <div v-if="showBanner"
     class="top-0 w-full z-100"
     :class="
       backdrop ? 'fixed h-screen w-screen bg-black bg-opacity-54' : 'sticky'
@@ -11,10 +11,12 @@
     >
       <slot>Site Banner</slot>
     </div>
+    <svg @click="setBannerCookie()" class="absolute top-0 right-0 h-8 w-8 cursor-pointer" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" stroke="currentColor"><path d="M6 18L18 6M6 6l12 12"></path></svg>
   </div>
 </template>
 
 <script>
+import cookie from '@/utils/cookie'
 export default {
   name: 'BaseSiteBanner',
   props: {
@@ -25,6 +27,27 @@ export default {
     backdrop: {
       type: Boolean,
       default: false
+    }
+  },
+  data: function () {
+    return {
+      showBanner: false
+      }
+  },
+  beforeMount () {
+    var bannerCookie = cookie.getCookie("banner");
+    //if bannerCookie === 1 that means user has seen the banner and dismissed it
+    if (bannerCookie == 1){
+      this.showBanner = false;
+    } else {
+      this.showBanner = true;
+    }
+  },
+  methods: {
+    setBannerCookie: function () {
+      this.showBanner= false;
+      //set cookie with name 'banner'. Set value to 1 which means true. Set expiration to 7 days.
+      cookie.setCookie("banner",1,7);
     }
   }
 };

--- a/src/utils/cookie.js
+++ b/src/utils/cookie.js
@@ -1,0 +1,23 @@
+export default {
+  getCookie(cname) {
+      var name = cname + "=";
+      var decodedCookie = decodeURIComponent(document.cookie);
+      var ca = decodedCookie.split(';');
+      for(var i = 0; i <ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') {
+          c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+          return c.substring(name.length, c.length);
+        }
+      }
+      return "";
+  },
+  setCookie(cname, cvalue, exdays) {
+      var d = new Date();
+      d.setTime(d.getTime() + (exdays*24*60*60*1000));
+      var expires = "expires="+ d.toUTCString();
+      document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+  }
+}


### PR DESCRIPTION
# Issue Being Addressed

None

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] Update to Existing Feature

# Description

Give user the ability to dismiss the beta banner if they want

# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.
1. Go to https://deploy-preview-319--foodouken.netlify.app/
2. Notice the banner has an 'x' on top right. Click it.
3. Notice banner is gone and does not show on any subsequent views

# Screenshots/casts

![Screen Shot 2020-07-09 at 7 19 01 PM](https://user-images.githubusercontent.com/44442621/87099983-2c371600-c219-11ea-940e-d25f54a37fd1.png)

# Additional Context

The banner will come back after 7 days. This duration can be extended, but I think 7 days is good to start with.