### PR TITLE
Added popup modal with transition for redirect when account exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "axios": "^0.19.2",
     "core-js": "^3.6.4",
+    "lodash-es": "^4.17.15",
     "register-service-worker": "^1.6.2",
     "tailwindcss": "^1.4.6",
     "typeface-open-sans": "0.0.75",

--- a/src/components/DuplicateAccount.vue
+++ b/src/components/DuplicateAccount.vue
@@ -45,11 +45,6 @@ import Button from '@/components/Button.vue';
 export default {
   name: 'DuplicateAccount',
   components: { Button },
-  data() {
-    return {
-      key: 'duplicate-account',
-    };
-  },
   methods: {
     goToLogin() {
       this.$router.push({ name: 'LogIn' });

--- a/src/components/DuplicateAccount.vue
+++ b/src/components/DuplicateAccount.vue
@@ -11,7 +11,7 @@
       class="flex justify-center items-center fixed w-screen h-screen top-0 left-0 z-50 bg-black bg-opacity-38"
     >
       <div class="bg-secondary shadow-24dp p-4 rounded-lg">
-        <div v-if="key === 'duplicate-account'">
+        <div>
           <h6 class="tg-body-mobile bg-surface text-white text-opacity-54">
             You already have an account <br />
             please login.
@@ -52,7 +52,7 @@ export default {
   },
   methods: {
     goToLogin() {
-      this.$router.push({ path: '/auth/login' });
+      this.$router.push({ name: 'LogIn' });
     },
     onCancel() {
        this.$emit('onCancel');

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="w-full">
     <div class="bg-secondary px-2 pt-4 pb-1 rounded-lg shadow">
-     <DuplicateAccount 
-        v-if="isDuplicate"
-        @onCancel="isDuplicate = false" 
-      />
+      <DuplicateAccount v-if="isDuplicate" @onCancel="isDuplicate = false" />
       <material-input
         v-model="$v.name.$model"
         label="Name"
@@ -70,6 +67,7 @@ import CheckoutNavBar from '@/components/forms/CheckoutNavBar.vue';
 import { mapGetters, mapMutations, mapActions } from 'vuex';
 import { required, email, minLength } from 'vuelidate/lib/validators';
 import DuplicateAccount from '@/components/DuplicateAccount.vue';
+import { get } from 'lodash-es';
 
 export default {
   name: 'CustomerInfo',
@@ -160,13 +158,14 @@ export default {
           this.pageChangeWrapper(2);
         })
         .catch(error => {
-          this.registerError = error.response.data[0].description;
-          if (error){
-            if (error.response.data[0].code == "DuplicateUserName"){
-              //this enables the DuplicateAccount component on CustomerInfo
-              this.isDuplicate = true;
-            }
-          }
+          this.registerError = get(
+            error,
+            'response.data[0].description',
+            'Something went wrong, try again please'
+          );
+          const isDuplicateUserError =
+            get(error, 'response.data[0].code', null) === 'DuplicateUserName';
+          this.isDuplicate = isDuplicateUserError;
         });
     },
     pageChangeWrapper(page) {

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -69,7 +69,7 @@ import TextArea from '@/components/inputs/TextArea.vue';
 import CheckoutNavBar from '@/components/forms/CheckoutNavBar.vue';
 import { mapGetters, mapMutations, mapActions } from 'vuex';
 import { required, email, minLength } from 'vuelidate/lib/validators';
-import DuplicateAccount from '@/components/inputs/DuplicateAccount.vue';
+import DuplicateAccount from '@/components/DuplicateAccount.vue';
 
 export default {
   name: 'CustomerInfo',
@@ -161,11 +161,9 @@ export default {
         })
         .catch(error => {
           this.registerError = error.response.data[0].description;
-          if (error.response.status === 400) {
-            if (error.response.data[0].code == "DuplicateUserName"){
-              //this enables the DuplicateAccount componet on Customer Info
-              this.isDuplicate = true;
-            }
+          if (error.response.data[0].code == "DuplicateUserName"){
+            //this enables the DuplicateAccount component on CustomerInfo
+            this.isDuplicate = true;
           }
         });
     },

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -161,9 +161,11 @@ export default {
         })
         .catch(error => {
           this.registerError = error.response.data[0].description;
-          if (error.response.data[0].code == "DuplicateUserName"){
-            //this enables the DuplicateAccount component on CustomerInfo
-            this.isDuplicate = true;
+          if (error){
+            if (error.response.data[0].code == "DuplicateUserName"){
+              //this enables the DuplicateAccount component on CustomerInfo
+              this.isDuplicate = true;
+            }
           }
         });
     },

--- a/src/components/forms/CustomerInfo.vue
+++ b/src/components/forms/CustomerInfo.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="w-full">
     <div class="bg-secondary px-2 pt-4 pb-1 rounded-lg shadow">
+     <DuplicateAccount 
+        v-if="isDuplicate"
+        @onCancel="isDuplicate = false" 
+      />
       <material-input
         v-model="$v.name.$model"
         label="Name"
@@ -65,18 +69,21 @@ import TextArea from '@/components/inputs/TextArea.vue';
 import CheckoutNavBar from '@/components/forms/CheckoutNavBar.vue';
 import { mapGetters, mapMutations, mapActions } from 'vuex';
 import { required, email, minLength } from 'vuelidate/lib/validators';
+import DuplicateAccount from '@/components/inputs/DuplicateAccount.vue';
 
 export default {
   name: 'CustomerInfo',
   components: {
     MaterialInput,
     TextArea,
-    CheckoutNavBar
+    CheckoutNavBar,
+    DuplicateAccount
   },
   data() {
     return {
       submitError: false,
-      registerError: ''
+      registerError: '',
+      isDuplicate: false
     };
   },
   validations: {
@@ -154,6 +161,12 @@ export default {
         })
         .catch(error => {
           this.registerError = error.response.data[0].description;
+          if (error.response.status === 400) {
+            if (error.response.data[0].code == "DuplicateUserName"){
+              //this enables the DuplicateAccount componet on Customer Info
+              this.isDuplicate = true;
+            }
+          }
         });
     },
     pageChangeWrapper(page) {

--- a/src/components/inputs/DuplicateAccount.vue
+++ b/src/components/inputs/DuplicateAccount.vue
@@ -1,0 +1,62 @@
+<template>
+<transition
+      enter-active-class="transition ease-out duration-200 transform"
+      enter-class="opacity-0 scale-95"
+      enter-to-class="opacity-100 scale-100"
+      leave-active-class="transition ease-in duration-150 transform"
+      leave-class="opacity-100 scale-100"
+      leave-to-class="opacity-0 scale-95"
+  >
+    <div
+      class="flex justify-center items-center fixed w-screen h-screen top-0 left-0 z-50 bg-black bg-opacity-38"
+    >
+      <div class="bg-secondary shadow-24dp p-4 rounded-lg">
+        <div v-if="key === 'duplicate-account'">
+          <h6 class="tg-body-mobile bg-surface text-white text-opacity-54">
+            You already have an account <br />
+            please login.
+          </h6>
+          <div class="mt-8 tg-color-label-mobile flex justify-end">
+            <Button
+              buttonBg="bg-secondary"
+              class="mr-4 text-white text-opacity-54 tg-color-label-mobile"
+              :isRipple="false"
+              width="w-auto"
+              padding="px-6 py-3"
+              title="Cancel"
+              @clicked="onCancel"
+            />
+            <Button
+              class="rounded-full text-white text-opacity-84 tg-color-label-mobile"
+              title="Login"
+              width="w-auto"
+              padding="px-6 py-3"
+              @clicked="goToLogin"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+</transition>
+</template>
+
+<script>
+import Button from '@/components/Button.vue';
+export default {
+  name: 'DuplicateAccount',
+  components: { Button },
+  data() {
+    return {
+      key: 'duplicate-account',
+    };
+  },
+  methods: {
+    goToLogin() {
+      this.$router.push({ path: '/auth/login' });
+    },
+    onCancel() {
+       this.$emit('onCancel');
+    }
+  }
+};
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5450,6 +5450,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"


### PR DESCRIPTION
# Issue Being Addressed

#268 

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[ ] Bug Fix
[ ] Refactor
[ ] New Feature
[x] Update to Existing Feature
[ ] Other (state below)

# Description
Error was shown when someone tried to order who already had an account. This notifies a user that they already have an account and gives them the option to go to login page.

# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.
1. Go to https://deploy-preview-322--foodouken.netlify.app/shop/foodie-27/your-address
2. Select an item and start the order. Fill in any name
3. For email use an existing account **bamboo.chow@gmail.com**
4. Fill in any phone number
5. Notice that you get a popup that lets you go to login page

# Screenshots/casts

![Screen Shot 2020-07-10 at 3 24 15 AM](https://user-images.githubusercontent.com/44442621/87127959-d84e2080-c25c-11ea-8b9f-c7a740198795.png)

# Additional Context

I think having a popup is better than just automatically redirecting them