### PR TITLE
hotfix: empty shop page

### DIFF
--- a/src/views/Shop.vue
+++ b/src/views/Shop.vue
@@ -155,11 +155,6 @@ export default {
         }
       ]
     };
-  },
-  beforeRouteEnter(to, from, next) {
-    if (to.params.isActive) {
-      next();
-    }
   }
 };
 </script>


### PR DESCRIPTION
Fix for empty shop page:

> when I visit here, I don't see anything https://staging.foodouken.com/shop/paul-chris-luke-47
> 
> I get a 401 on https://stagingapi.whynot.earth/api/v0/authentication/ping
> is that related to what you fixed for browtricks?

There was a defective `isActive` checking in shop page on beforeRouteEnter. Disabled that rule.