### PR TITLE
made logo rounded, but SEO image is still square

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,24 +2,24 @@
   <div>
     <div class="text-center">
       <div class="my-8">
-        <div class="bg-logo mx-auto h-40 w-40 p-5 rounded-full">
-          <img :src="home.custom.logo" alt="Logo image" />
+        <div class="w-40 h-40 p-5 mx-auto rounded-full bg-logo">
+          <img :src="home.custom.logo" class="rounded-full lg:w-20 lg:h-20" alt="Logo image" />
         </div>
       </div>
-      <h1 class="text-white text-4xl font-bold">{{ home.title }}</h1>
-      <h2 class="text-2xl text-gray-500 font-semibold mb-8">
+      <h1 class="text-4xl font-bold text-white">{{ home.title }}</h1>
+      <h2 class="mb-8 text-2xl font-semibold text-gray-500">
         {{ home.description }}
       </h2>
       <p
-        class="text-gray-500 text-base mt-2 text-justify lg:text-center mx-auto max-w-lg"
+        class="max-w-lg mx-auto mt-2 text-base text-justify text-gray-500 lg:text-center"
       >
         {{ home.custom.description }}
       </p>
     </div>
     <hr class="my-8 border-gray-700" />
-    <section class="flex my-4 lg:max-w-3xl xl:max-w-5xl mx-auto">
+    <section class="flex mx-auto my-4 lg:max-w-3xl xl:max-w-5xl">
       <ul
-        class="flex flex-wrap w-full items-stretch justify-center h-full mx-auto"
+        class="flex flex-wrap items-stretch justify-center w-full h-full mx-auto"
       >
         <li
           v-for="tenant in activeTenants"
@@ -31,7 +31,7 @@
               name: 'Shop',
               params: { slug: tenant.slug, isActive: tenant.isActive }
             }"
-            class="bg-secondary rounded-md overflow-hidden flex flex-col h-full"
+            class="flex flex-col h-full overflow-hidden rounded-md bg-secondary"
           >
             <tenant-card :tenant="tenant" />
           </router-link>
@@ -39,9 +39,9 @@
       </ul>
     </section>
     <hr class="my-8 border-gray-700" />
-    <section class="flex my-4 lg:max-w-3xl xl:max-w-5xl mx-auto">
+    <section class="flex mx-auto my-4 lg:max-w-3xl xl:max-w-5xl">
       <ul
-        class="flex flex-wrap w-full items-stretch justify-center h-full mx-auto"
+        class="flex flex-wrap items-stretch justify-center w-full h-full mx-auto"
       >
         <li
           v-for="tenant in inactiveTenants"
@@ -49,7 +49,7 @@
           class="w-full py-2 md:w-1/2 md:px-2 xl:w-1/3"
         >
           <div
-            class="bg-secondary rounded-md overflow-hidden flex flex-col h-full"
+            class="flex flex-col h-full overflow-hidden rounded-md bg-secondary"
           >
             <tenant-card :tenant="tenant" />
           </div>
@@ -59,7 +59,7 @@
     <CreditFooter />
     <SnackBar :showSnackBar="showPrivacySnackBar">
       <div
-        class="flex items-center justify-between text-white w-full h-12 tg-caption-mobile leading-4 p-4"
+        class="flex items-center justify-between w-full h-12 p-4 leading-4 text-white tg-caption-mobile"
       >
         <p>
           Gotta agree to
@@ -72,7 +72,7 @@
           </a>
         </p>
         <p
-          class="text-button uppercase cursor-pointer"
+          class="uppercase cursor-pointer text-button"
           @click="setSnackBarCookie"
         >
           Agree

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,7 +3,7 @@
     <div class="text-center">
       <div class="my-8">
         <div class="w-40 h-40 p-5 mx-auto rounded-full bg-logo">
-          <img :src="home.custom.logo" class="rounded-full lg:w-20 lg:h-20" alt="Logo image" />
+          <img :src="home.custom.logo" class="rounded-full" alt="Logo - Blobby from Foodouken" />
         </div>
       </div>
       <h1 class="text-4xl font-bold text-white">{{ home.title }}</h1>


### PR DESCRIPTION
# Issue Being Addressed

none

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[ ] Bug Fix
[ ] Refactor
[ ] New Feature
[x] Update to Existing Feature
[ ] Other (state below)

# Description

The logo was square on HP, but now its rounded.

# Screenshots/casts
Before:
<img width="243" alt="Screen Shot 2020-08-21 at 12 31 12 AM" src="https://user-images.githubusercontent.com/44442621/90852508-a644d980-e345-11ea-8233-c265873b989c.png">

After:
<img width="291" alt="Screen Shot 2020-08-21 at 12 31 07 AM" src="https://user-images.githubusercontent.com/44442621/90852515-a9d86080-e345-11ea-8ebc-b16f76217be8.png">
Live Preview: https://deploy-preview-381--foodouken.netlify.app/

# Additional Context

The reason this image is not a PNG is because for SEO reasons, so kept it a JPG. Just rounded it with css