### PR TITLE
Made price always have two decimal places to stay consistent 

### DIFF
--- a/src/components/cards/ProductCard.vue
+++ b/src/components/cards/ProductCard.vue
@@ -18,11 +18,11 @@
           {{ product.discountPercent }}% OFF
         </span>
         <div class="my-1 text-gray-500">
-          <span class="mr-1 line-through">${{ product.originalPrice | currencyFormat }}</span>
-          <span>${{ product.price | currencyFormat }}</span>
+          <span class="mr-1 line-through">{{ product.originalPrice | formatPrice }}</span>
+          <span>{{ product.price | formatPrice }}</span>
         </div>
       </div>
-      <p v-else class="block mx-4 my-1 text-gray-500">${{ product.price | currencyFormat }}</p>
+      <p v-else class="block mx-4 my-1 text-gray-500">{{ product.price | formatPrice }}</p>
     </div>
     <div class="relative flex-grow">
       <div
@@ -53,8 +53,8 @@ export default {
     ...mapActions('cart', ['addCartProduct'])
   },
   filters: {
-    currencyFormat: function (value) {
-      return value.toFixed(2)
+    formatPrice: price => {
+      return `$${price.toFixed(2)}`;
     }
   }
 };

--- a/src/components/cards/ProductCard.vue
+++ b/src/components/cards/ProductCard.vue
@@ -2,31 +2,31 @@
   <div
     v-if="product"
     @click="addCartProduct(product)"
-    class="product-card bg-secondary flex flex-row shadow-md rounded-lg h-24 mb-4 cursor-pointer transition duration-300 transform hover:opacity-75"
+    class="flex flex-row h-24 mb-4 transition duration-300 transform rounded-lg shadow-md cursor-pointer product-card bg-secondary hover:opacity-75"
   >
     <img
       :src="product.imageUrl"
       alt="Product image"
-      class="p-1/2 w-20 h-full object-cover rounded-l-lg"
+      class="object-cover w-20 h-full rounded-l-lg p-1/2"
     />
     <div class="my-auto">
-      <p class="mx-4 text-gray-400 my-1 text-base md:text-lg break-words">
+      <p class="mx-4 my-1 text-base text-gray-400 break-words md:text-lg">
         {{ product.name }}
       </p>
       <div v-if="product.discountPercent > 0" class="mx-4 text-xs sm:text-sm">
-        <span class="rounded text-white bg-button px-1 my-1">
+        <span class="px-1 my-1 text-white rounded bg-button">
           {{ product.discountPercent }}% OFF
         </span>
-        <div class="text-gray-500 my-1">
-          <span class="line-through mr-1">${{ product.originalPrice }}</span>
-          <span>${{ product.price }}</span>
+        <div class="my-1 text-gray-500">
+          <span class="mr-1 line-through">${{ product.originalPrice | currencyFormat }}</span>
+          <span>${{ product.price | currencyFormat }}</span>
         </div>
       </div>
-      <p v-else class="mx-4 text-gray-500  my-1 block">${{ product.price }}</p>
+      <p v-else class="block mx-4 my-1 text-gray-500">${{ product.price | currencyFormat }}</p>
     </div>
     <div class="relative flex-grow">
       <div
-        class="ripple absolute flex justify-center items-center w-10 h-10 text-align-center border border-solid rounded-full btn-plus cursor-pointer select-none"
+        class="absolute flex items-center justify-center w-10 h-10 border border-solid rounded-full cursor-pointer select-none ripple text-align-center btn-plus"
       >
         <img
           src="@/assets/add.png"
@@ -51,6 +51,11 @@ export default {
   },
   methods: {
     ...mapActions('cart', ['addCartProduct'])
+  },
+  filters: {
+    currencyFormat: function (value) {
+      return value.toFixed(2)
+    }
   }
 };
 </script>

--- a/src/components/cart/CartItem.vue
+++ b/src/components/cart/CartItem.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    class="flex flex-row my-2 px-2 relative items-center transition-all duration-300"
+    class="relative flex flex-row items-center px-2 my-2 transition-all duration-300"
   >
     <div
-      class="absolute top-0 left-0 bg-button rounded-full h-4 w-4 cursor-pointer select-none"
+      class="absolute top-0 left-0 w-4 h-4 rounded-full cursor-pointer select-none bg-button"
       @click="remove"
     >
       <img
@@ -15,25 +15,25 @@
     </div>
     <img
       :src="cartItem.product.imageUrl"
-      class="h-12 w-12 my-auto"
+      class="w-12 h-12 my-auto"
       alt="Product image"
     />
-    <div class="mx-2 w-full flex flex-col truncate">
+    <div class="flex flex-col w-full mx-2 truncate">
       <span class="text-gray-400 truncate">{{ cartItem.product.name }} </span>
       <div v-if="cartItem.product.discountPercent">
-        <span class="line-through text-gray-500 mr-1">
-          ${{ cartItem.product.originalPrice }}
+        <span class="mr-1 text-gray-500 line-through">
+          {{ cartItem.product.originalPrice | formatPrice }}
         </span>
-        <span class="text-gray-500">${{ cartItem.product.price }}</span>
+        <span class="text-gray-500">{{ cartItem.product.price | formatPrice }}</span>
       </div>
-      <span v-else class="text-gray-500">${{ cartItem.product.price }}</span>
+      <span v-else class="text-gray-500">{{ cartItem.product.price | formatPrice }}</span>
     </div>
-    <div class="flex items-center text-gray-500 font-bold text-lg">
-      <div class="cursor-pointer w-6 select-none" @click="decrement">
+    <div class="flex items-center text-lg font-bold text-gray-500">
+      <div class="w-6 cursor-pointer select-none" @click="decrement">
         <img
           :src="minus"
           alt="-"
-          class="pointer-events-none py-4"
+          class="py-4 pointer-events-none"
           draggable="false"
         />
       </div>
@@ -42,13 +42,13 @@
         name="quantity"
         min="1"
         v-model.number="cartItem.count"
-        class="bg-transparent w-8 py-3 text-center font-bold text-white"
+        class="w-8 py-3 font-bold text-center text-white bg-transparent"
       />
-      <div class="cursor-pointer w-6 select-none" @click="increment">
+      <div class="w-6 cursor-pointer select-none" @click="increment">
         <img
           :src="plus"
           alt="+"
-          class="pointer-events-none py-4"
+          class="py-4 pointer-events-none"
           draggable="false"
         />
       </div>
@@ -85,6 +85,11 @@ export default {
     },
     remove() {
       this.$store.dispatch('cart/removeCartProduct', this.cartItem.product);
+    }
+  },
+  filters: {
+    formatPrice: price => {
+      return `$${price.toFixed(2)}`;
     }
   }
 };


### PR DESCRIPTION
# Issue Being Addressed

none.

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[ ] Bug Fix
[ ] Refactor
[ ] New Feature
[x] Update to Existing Feature
[ ] Other (state below)

# Description

All prices are now forced to always have 2 decimal places to stay consistent.

# Screenshots/casts

Before:
<img width="896" alt="Screen Shot 2020-08-21 at 2 04 57 AM" src="https://user-images.githubusercontent.com/44442621/90857827-f4140e80-e352-11ea-83ec-e6e6866bf8d8.png">

After:
<img width="905" alt="Screen Shot 2020-08-21 at 2 05 05 AM" src="https://user-images.githubusercontent.com/44442621/90857838-fa09ef80-e352-11ea-9129-1d3e3c553361.png">

Live Preview: https://deploy-preview-382--foodouken.netlify.app/


# Additional Context

No longer will you see **$2.5** and **$3**. Now you will always see **$2.50**, **$3.00** etc...