### PR TITLE
added conditions for Staging / Production builds for Rollbar

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -36,9 +36,12 @@ Vue.use(VueGoogleMaps, {
 Vue.config.productionTip = false;
 
 Vue.prototype.$rollbar = new Rollbar({
-  accessToken: '05b7f5cb9a5d4574ba92150f543a8922',
+  accessToken: '04f340e4322f438aa41f544423db8dc2',
   captureUncaught: true,
-  captureUnhandledRejections: true
+  captureUnhandledRejections: true,
+  payload: {
+    environment: process.env.NODE_ENV == "development" ? "staging" : "production"
+  }
 });
 
 Vue.config.errorHandler = (err, vm) => {

--- a/src/main.js
+++ b/src/main.js
@@ -40,7 +40,7 @@ Vue.prototype.$rollbar = new Rollbar({
   captureUncaught: true,
   captureUnhandledRejections: true,
   payload: {
-    environment: process.env.NODE_ENV == "development" ? "staging" : "production"
+    environment: process.env.NODE_ENV != "production" ? "staging" : "production"
   }
 });
 


### PR DESCRIPTION
# Issue Being Addressed

#354 

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[ ] Bug Fix
[ ] Refactor
[ ] New Feature
[x] Update to Existing Feature
[ ] Other (state below)

# Screenshots/casts
Added dynamic function based on build setting. Anytime the build IS NOT 'production' then the environment for Rollbar will be staging. When in production the environment will be 'production'.
<img width="552" alt="Screen Shot 2020-10-20 at 1 12 25 AM" src="https://user-images.githubusercontent.com/44442621/96542974-544f0000-1271-11eb-8ddb-28071563a005.png">
